### PR TITLE
Add basic mailbox ownership model for `HttpExchange`

### DIFF
--- a/academy/exchange/cloud/server.py
+++ b/academy/exchange/cloud/server.py
@@ -74,24 +74,49 @@ _UNAUTHORIZED_CODE = 405
 
 class _MailboxManager:
     def __init__(self) -> None:
+        self._owners: dict[EntityId, str | None] = {}
         self._mailboxes: dict[EntityId, AsyncQueue[Message]] = {}
         self._behaviors: dict[AgentId[Any], tuple[str, ...]] = {}
 
-    def check_mailbox(self, uid: EntityId) -> bool:
+    def has_permissions(
+        self,
+        client: str | None,
+        entity: EntityId,
+    ) -> bool:
+        return entity not in self._owners or self._owners[entity] == client
+
+    def check_mailbox(self, client: str | None, uid: EntityId) -> bool:
+        if not self.has_permissions(client, uid):
+            raise UnauthorizedError(
+                'Client does not have correct permissions.',
+            )
+
         return uid in self._mailboxes
 
     def create_mailbox(
         self,
+        client: str | None,
         uid: EntityId,
         behavior: tuple[str, ...] | None = None,
     ) -> None:
+        if not self.has_permissions(client, uid):
+            raise UnauthorizedError(
+                'Client does not have correct permissions.',
+            )
+
         if uid not in self._mailboxes or self._mailboxes[uid].closed():
             self._mailboxes[uid] = AsyncQueue()
+            self._owners[uid] = client
             if behavior is not None and isinstance(uid, AgentId):
                 self._behaviors[uid] = behavior
             logger.info('Created mailbox for %s', uid)
 
-    async def terminate(self, uid: EntityId) -> None:
+    async def terminate(self, client: str | None, uid: EntityId) -> None:
+        if not self.has_permissions(client, uid):
+            raise UnauthorizedError(
+                'Client does not have correct permissions.',
+            )
+
         mailbox = self._mailboxes.get(uid, None)
         if mailbox is not None:
             await mailbox.close()
@@ -99,11 +124,14 @@ class _MailboxManager:
 
     async def discover(
         self,
+        client: str | None,
         behavior: str,
         allow_subclasses: bool,
     ) -> list[AgentId[Any]]:
         found: list[AgentId[Any]] = []
         for aid, behaviors in self._behaviors.items():
+            if not self.has_permissions(client, aid):
+                continue
             if self._mailboxes[aid].closed():
                 continue
             if behavior == behaviors[0] or (
@@ -112,7 +140,12 @@ class _MailboxManager:
                 found.append(aid)
         return found
 
-    async def get(self, uid: EntityId) -> Message:
+    async def get(self, client: str | None, uid: EntityId) -> Message:
+        if not self.has_permissions(client, uid):
+            raise UnauthorizedError(
+                'Client does not have correct permissions.',
+            )
+
         try:
             return await self._mailboxes[uid].get()
         except KeyError as e:
@@ -120,7 +153,12 @@ class _MailboxManager:
         except QueueClosedError as e:
             raise MailboxClosedError(uid) from e
 
-    async def put(self, message: Message) -> None:
+    async def put(self, client: str | None, message: Message) -> None:
+        if not self.has_permissions(client, message.dest):
+            raise UnauthorizedError(
+                'Client does not have correct permissions.',
+            )
+
         try:
             await self._mailboxes[message.dest].put(message)
         except KeyError as e:
@@ -151,7 +189,14 @@ async def _create_mailbox_route(request: Request) -> Response:
             text='Missing or invalid mailbox ID',
         )
 
-    manager.create_mailbox(mailbox_id, behavior)
+    client_id = request.headers.get('client_id', None)
+    try:
+        manager.create_mailbox(client_id, mailbox_id, behavior)
+    except UnauthorizedError:
+        return Response(
+            status=_UNAUTHORIZED_CODE,
+            text='Incorrect permissions',
+        )
     return Response(status=_OKAY_CODE)
 
 
@@ -170,7 +215,14 @@ async def _terminate_route(request: Request) -> Response:
             text='Missing or invalid mailbox ID',
         )
 
-    await manager.terminate(mailbox_id)
+    client_id = request.headers.get('client_id', None)
+    try:
+        await manager.terminate(client_id, mailbox_id)
+    except UnauthorizedError:
+        return Response(
+            status=_UNAUTHORIZED_CODE,
+            text='Incorrect permissions',
+        )
     return Response(status=_OKAY_CODE)
 
 
@@ -187,7 +239,18 @@ async def _discover_route(request: Request) -> Response:
             text='Missing or invalid arguments',
         )
 
-    agent_ids = await manager.discover(behavior, allow_subclasses)
+    client_id = request.headers.get('client_id', None)
+    try:
+        agent_ids = await manager.discover(
+            client_id,
+            behavior,
+            allow_subclasses,
+        )
+    except UnauthorizedError:
+        return Response(
+            status=_UNAUTHORIZED_CODE,
+            text='Incorrect permissions',
+        )
     return json_response(
         {'agent_ids': ','.join(str(aid.uid) for aid in agent_ids)},
     )
@@ -208,7 +271,14 @@ async def _check_mailbox_route(request: Request) -> Response:
             text='Missing or invalid mailbox ID',
         )
 
-    exists = manager.check_mailbox(mailbox_id)
+    client_id = request.headers.get('client_id', None)
+    try:
+        exists = manager.check_mailbox(client_id, mailbox_id)
+    except UnauthorizedError:
+        return Response(
+            status=_UNAUTHORIZED_CODE,
+            text='Incorrect permissions',
+        )
     return json_response({'exists': exists})
 
 
@@ -225,12 +295,18 @@ async def _send_message_route(request: Request) -> Response:
             text='Missing or invalid message',
         )
 
+    client_id = request.headers.get('client_id', None)
     try:
-        await manager.put(message)
+        await manager.put(client_id, message)
     except BadEntityIdError:
         return Response(status=_NOT_FOUND_CODE, text='Unknown mailbox ID')
     except MailboxClosedError:
         return Response(status=_FORBIDDEN_CODE, text='Mailbox was closed')
+    except UnauthorizedError:
+        return Response(
+            status=_UNAUTHORIZED_CODE,
+            text='Incorrect permissions',
+        )
     else:
         return Response(status=_OKAY_CODE)
 
@@ -251,11 +327,17 @@ async def _recv_message_route(request: Request) -> Response:
         )
 
     try:
-        message = await manager.get(mailbox_id)
+        client_id = request.headers.get('client_id', None)
+        message = await manager.get(client_id, mailbox_id)
     except BadEntityIdError:
         return Response(status=_NOT_FOUND_CODE, text='Unknown mailbox ID')
     except MailboxClosedError:
         return Response(status=_FORBIDDEN_CODE, text='Mailbox was closed')
+    except UnauthorizedError:
+        return Response(
+            status=_UNAUTHORIZED_CODE,
+            text='Incorrect permissions',
+        )
     else:
         return json_response({'message': message.model_dump_json()})
 
@@ -297,7 +379,9 @@ def authenticate_factory(
                 text='Missing required headers.',
             )
 
-        request['client_id'] = str(client_uuid)
+        headers = request.headers.copy()
+        headers['client_id'] = str(client_uuid)
+        request = request.clone(headers=headers)
         return await handler(request)
 
     return authenticate

--- a/academy/exchange/cloud/server.py
+++ b/academy/exchange/cloud/server.py
@@ -240,17 +240,12 @@ async def _discover_route(request: Request) -> Response:
         )
 
     client_id = request.headers.get('client_id', None)
-    try:
-        agent_ids = await manager.discover(
-            client_id,
-            behavior,
-            allow_subclasses,
-        )
-    except UnauthorizedError:
-        return Response(
-            status=_UNAUTHORIZED_CODE,
-            text='Incorrect permissions',
-        )
+    agent_ids = await manager.discover(
+        client_id,
+        behavior,
+        allow_subclasses,
+    )
+
     return json_response(
         {'agent_ids': ','.join(str(aid.uid) for aid in agent_ids)},
     )


### PR DESCRIPTION
# Description
Currently all authenticated users can read and write from any mailbox. This PR implements a basic ownership model, so only agents created by the same client can discover and communicate with each other. This is implemented by passing around a bearer token when starting agents (not a good pattern). 


### Type of Change
- [x] New feature (non-breaking change which adds functionality)

## Testing
Tests added to verify

## Pull Request Checklist

Please confirm the PR meets the following requirements.
- [x] Relevant tags are added (breaking, bug, dependencies, documentation, enhancement, refactor).
- [x] Code changes pass `pre-commit` (e.g., ruff, mypy, etc.).
- [x] Tests have been added to show the fix is effective or that the new feature works.
- [x] New and existing unit tests pass locally with the changes.
- [x] Docs have been updated and reviewed if relevant.
