### PR TITLE
Add examples of logging configuration within the `Manager`

### DIFF
--- a/academy/manager.py
+++ b/academy/manager.py
@@ -75,6 +75,12 @@ class Manager(Generic[ExchangeTransportT], NoPickleMixin):
         running agents will be shutdown, any agent handles created by the
         manager will be closed, and the executors will be shutdown.
 
+    Tip:
+        When using
+        [`ProcessPoolExecutors`][concurrent.futures.ProcessPoolExecutor],
+        use the `initializer` argument to configure logging in the worker
+        processes that will execute agents.
+
     Note:
         The manager takes ownership of the exchange client and executors,
         meaning the manager will clean up those resources when the manager

--- a/docs/faq.md
+++ b/docs/faq.md
@@ -2,6 +2,29 @@
 
 *[Open a new issue](https://github.com/proxystore/academy/issues){target=_bank} if you have a question not answered in the FAQ, Guides, or API docs.*
 
-!!! warning
+## Logging
 
-    FAQs are under development!
+### How to enable agent logging in the Manager?
+
+The [`Manager`][academy.manager.Manager] does not configure logging when an agent starts on a worker within an executor.
+We recommend using the worker initialization features of executors to configure logging, such as by calling [`init_logging()`][academy.logging.init_logging] or [`logging.basicConfig()`][logging.basicConfig].
+For example, use the `initializer` argument when using a [`ProcessPoolExecutor`][concurrent.futures.ProcessPoolExecutor].
+
+```python
+import logging
+import multiprocessing
+from concurrent.futures import ProcessPoolExecutor
+from academy.logging import init_logging
+from academy.manager import Manager
+
+mp_context = multiprocessing.get_context('spawn')
+executor = ProcessPoolExecutor(
+    max_workers=3,
+    initializer=init_logging,
+    initargs=(logging.INFO,),
+    mp_context=mp_context,
+)
+
+async with await Manager(..., executors=executor) as manager:
+    ...
+```

--- a/examples/04-execution/run-04.py
+++ b/examples/04-execution/run-04.py
@@ -51,7 +51,11 @@ async def main() -> int:
 
     with spawn_http_exchange('localhost', EXCHANGE_PORT) as factory:
         mp_context = multiprocessing.get_context('spawn')
-        executor = ProcessPoolExecutor(max_workers=3, mp_context=mp_context)
+        executor = ProcessPoolExecutor(
+            max_workers=3,
+            initializer=init_logging,
+            mp_context=mp_context,
+        )
 
         async with await Manager.from_exchange_factory(
             factory=factory,


### PR DESCRIPTION
# Description
<!--- Describe your changes in detail --->

Added some examples of best practices for configuring logging for agents launched my the manager. The original issue (#102) discussed having the `Agent` configure logging on startup, but I think that is a little brittle as we really only want to configure logging once in each process. Some executors like the `ProcessPoolExecutor` have mechanisms for process initialization which I think is better suited for logging setup.

This doesn't quite help with Parsl/Globus Compute type executors, so possible in the future we want to add some sort of `initializer` argument.

### Fixes
<!--- List any issue numbers above that this PR addresses --->

- Fixes #102

### Type of Change
<!--- Check which off the following types describe this PR --->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Refactoring (internal implementation changes)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Documentation update (no changes to the code)
- [ ] CI change (changes to CI workflows, packages, templates, etc.)
- [ ] Version changes (changes to the package or dependency versions)

## Testing
<!--- Please describe the test ran to verify changes --->

N/A

## Pull Request Checklist

Please confirm the PR meets the following requirements.
- [x] Relevant tags are added (breaking, bug, dependencies, documentation, enhancement, refactor).
- [x] Code changes pass `pre-commit` (e.g., ruff, mypy, etc.).
- [x] Tests have been added to show the fix is effective or that the new feature works.
- [x] New and existing unit tests pass locally with the changes.
- [x] Docs have been updated and reviewed if relevant.
