### PR TITLE
Add context pass through for action methods

### DIFF
--- a/academy/behavior.py
+++ b/academy/behavior.py
@@ -12,6 +12,7 @@ from typing import Any
 from typing import Callable
 from typing import Generic
 from typing import Literal
+from typing import overload
 from typing import Protocol
 from typing import TYPE_CHECKING
 from typing import TypeVar
@@ -258,7 +259,8 @@ class Behavior:
 class Action(Generic[P, R_co], Protocol):
     """Action method protocol."""
 
-    _agent_method_type: Literal['action'] = 'action'
+    _agent_method_type: Literal['action']
+    _action_method_context: bool
 
     async def __call__(self, *arg: P.args, **kwargs: P.kwargs) -> R_co:
         """Expected signature of methods decorated as an action.
@@ -271,7 +273,7 @@ class Action(Generic[P, R_co], Protocol):
 class ControlLoop(Protocol):
     """Control loop method protocol."""
 
-    _agent_method_type: Literal['loop'] = 'loop'
+    _agent_method_type: Literal['loop']
 
     async def __call__(self, shutdown: asyncio.Event) -> None:
         """Expected signature of methods decorated as a control loop.
@@ -286,7 +288,22 @@ class ControlLoop(Protocol):
         ...
 
 
-def action(method: ActionMethod[P, R]) -> ActionMethod[P, R]:
+@overload
+def action(method: ActionMethod[P, R]) -> ActionMethod[P, R]: ...
+
+
+@overload
+def action(
+    *,
+    context: bool = False,
+) -> Callable[[ActionMethod[P, R]], ActionMethod[P, R]]: ...
+
+
+def action(
+    method: ActionMethod[P, R] | None = None,
+    *,
+    context: bool = False,
+) -> ActionMethod[P, R] | Callable[[ActionMethod[P, R]], ActionMethod[P, R]]:
     """Decorator that annotates a method of a behavior as an action.
 
     Marking a method of a behavior as an action makes the method available
@@ -297,15 +314,57 @@ def action(method: ActionMethod[P, R]) -> ActionMethod[P, R]:
     Example:
         ```python
         from academy.behavior import Behavior, action
+        from academy.context import ActionContext
 
         class Example(Behavior):
             @action
-            async def perform(self):
+            async def perform(self) -> ...:
+                ...
+
+            @action(context=True)
+            async def perform_with_ctx(self, *, context: ActionContext) -> ...:
                 ...
         ```
+
+    Args:
+        method: Method to decorate as an action.
+        context: Specify that the action method expects a context argument.
+            The `context` will be provided at runtime as a keyword argument.
+
+    Raises:
+        TypeError: If `context=True` and the method does not have a parameter
+            named `context` or if `context` is a positional only argument.
     """
-    method._agent_method_type = 'action'  # type: ignore[attr-defined]
-    return method
+
+    def decorator(method_: ActionMethod[P, R]) -> ActionMethod[P, R]:
+        # Typing the requirement that if context=True then params P should
+        # contain a keyword argument named "context" is not easily annotated
+        # for mypy so instead we check at runtime.
+        if context:
+            sig = inspect.signature(method_)
+            if 'context' not in sig.parameters:
+                raise TypeError(
+                    f'Action method "{method_.__name__}" must accept a '
+                    '"context" keyword argument when used with '
+                    '@action(context=True).',
+                )
+            if (
+                sig.parameters['context'].kind
+                != inspect.Parameter.KEYWORD_ONLY
+            ):
+                raise TypeError(
+                    'The "context" argument to action method '
+                    f'"{method_.__name__}" must be a keyword only argument.',
+                )
+
+        method_._agent_method_type = 'action'  # type: ignore[attr-defined]
+        method_._action_method_context = context  # type: ignore[attr-defined]
+        return method_
+
+    if method is None:
+        return decorator
+    else:
+        return decorator(method)
 
 
 def loop(method: LoopMethod[BehaviorT]) -> LoopMethod[BehaviorT]:

--- a/academy/context.py
+++ b/academy/context.py
@@ -8,12 +8,61 @@ from typing import TYPE_CHECKING
 from typing import TypeVar
 
 from academy.exchange import AgentExchangeClient
+from academy.handle import Handle
 from academy.identifier import AgentId
+from academy.identifier import EntityId
+from academy.identifier import UserId
 
 if TYPE_CHECKING:
     from academy.behavior import BehaviorT
 else:
     BehaviorT = TypeVar('BehaviorT')
+
+
+class ActionContext:
+    """Action invocation context."""
+
+    def __init__(
+        self,
+        source_id: EntityId,
+        exchange_client: AgentExchangeClient[Any, Any],
+    ) -> None:
+        self._source_id = source_id
+        self._exchange_client = exchange_client
+        self._source_handle: Handle[Any] | None = None
+
+    @property
+    def source_id(self) -> EntityId:
+        """ID of the source that requested the action."""
+        return self._source_id
+
+    @property
+    def source_handle(self) -> Handle[Any]:
+        """Get a handle to the source agent of the request.
+
+        Returns:
+            Handle to the agent that made the request.
+
+        Raises:
+            TypeError: If the source is a user entity.
+        """
+        if isinstance(self.source_id, UserId):
+            raise TypeError(
+                'Cannot create handle to source because it is a user entity.',
+            )
+        if self._source_handle is None:
+            self._source_handle = self._exchange_client.get_handle(
+                self.source_id,
+            )
+        return self._source_handle
+
+    def is_agent_source(self) -> bool:
+        """Is the source an agent."""
+        return isinstance(self.source_id, AgentId)
+
+    def is_user_source(self) -> bool:
+        """Is the source a user."""
+        return isinstance(self.source_id, UserId)
 
 
 @dataclasses.dataclass(frozen=True)

--- a/academy/exchange/__init__.py
+++ b/academy/exchange/__init__.py
@@ -230,10 +230,7 @@ class ExchangeClient(abc.ABC, Generic[ExchangeTransportT]):
         """Get an exchange factory."""
         return self._transport.factory()
 
-    async def get_handle(
-        self,
-        aid: AgentId[BehaviorT],
-    ) -> RemoteHandle[BehaviorT]:
+    def get_handle(self, aid: AgentId[BehaviorT]) -> RemoteHandle[BehaviorT]:
         """Create a new handle to an agent.
 
         A handle acts like a reference to a remote agent, enabling a user

--- a/academy/handle.py
+++ b/academy/handle.py
@@ -361,7 +361,7 @@ class UnboundRemoteHandle(Generic[BehaviorT]):
         """Raises [`RuntimeError`][RuntimeError] when unbound."""
         raise RuntimeError('An unbound handle has no client ID.')
 
-    async def bind_to_client(
+    def bind_to_client(
         self,
         client: ExchangeClient[Any],
     ) -> RemoteHandle[BehaviorT]:
@@ -373,7 +373,7 @@ class UnboundRemoteHandle(Generic[BehaviorT]):
         Returns:
             Remote handle bound to the exchange client.
         """
-        return await client.get_handle(self.agent_id)
+        return client.get_handle(self.agent_id)
 
     async def action(
         self,

--- a/academy/manager.py
+++ b/academy/manager.py
@@ -205,7 +205,7 @@ class Manager(Generic[ExchangeTransportT], NoPickleMixin):
         """
         for acb in self._acbs.values():
             if not acb.task.done():
-                handle = await self.get_handle(acb.agent_id)
+                handle = self.get_handle(acb.agent_id)
                 with contextlib.suppress(MailboxClosedError):
                     await handle.shutdown()
         logger.debug('Requested shutdown from all agents')
@@ -387,12 +387,12 @@ class Manager(Generic[ExchangeTransportT], NoPickleMixin):
 
         acb = _ACB(agent_id=agent_id, executor=executor, task=task)
         self._acbs[agent_id] = acb
-        handle = await self.get_handle(agent_id)
+        handle = self.get_handle(agent_id)
         logger.info('Launched agent (%s; %s)', agent_id, behavior)
         self._warn_executor_overloaded(executor_instance, executor)
         return handle
 
-    async def get_handle(
+    def get_handle(
         self,
         agent: AgentId[BehaviorT] | AgentRegistration[BehaviorT],
     ) -> RemoteHandle[BehaviorT]:
@@ -413,7 +413,7 @@ class Manager(Generic[ExchangeTransportT], NoPickleMixin):
         handle = self._handles.get(agent_id, None)
         if handle is not None and not handle.closed():
             return handle
-        handle = await self.exchange_client.get_handle(agent_id)
+        handle = self.exchange_client.get_handle(agent_id)
         self._handles[agent_id] = handle
         return handle
 
@@ -477,7 +477,7 @@ class Manager(Generic[ExchangeTransportT], NoPickleMixin):
         if self._acbs[agent_id].task.done():
             return
 
-        handle = await self.get_handle(agent_id)
+        handle = self.get_handle(agent_id)
         with contextlib.suppress(MailboxClosedError):
             await handle.shutdown()
 

--- a/tests/context_test.py
+++ b/tests/context_test.py
@@ -1,0 +1,58 @@
+from __future__ import annotations
+
+from typing import Any
+
+import pytest
+
+from academy.context import ActionContext
+from academy.exchange import UserExchangeClient
+from academy.identifier import AgentId
+from academy.identifier import UserId
+from testing.behavior import EmptyBehavior
+
+
+@pytest.mark.asyncio
+async def test_action_context_agent_source(
+    exchange: UserExchangeClient[Any],
+) -> None:
+    factory = exchange.factory()
+    source_id: AgentId[EmptyBehavior] = AgentId.new()
+    registration = await exchange.register_agent(EmptyBehavior)
+
+    async def _request_handler(_: Any) -> None:  # pragma: no cover
+        pass
+
+    async with await factory.create_agent_client(
+        registration,
+        _request_handler,
+    ) as agent_client:
+        context = ActionContext(source_id, agent_client)
+        assert context.is_agent_source()
+        assert not context.is_user_source()
+        handle = context.source_handle
+        assert handle.agent_id == source_id
+        # Check that handle.source_handle is cached
+        assert context.source_handle is handle
+
+
+@pytest.mark.asyncio
+async def test_action_context_user_source(
+    exchange: UserExchangeClient[Any],
+) -> None:
+    factory = exchange.factory()
+    source_id = UserId.new()
+    registration = await exchange.register_agent(EmptyBehavior)
+
+    async def _request_handler(_: Any) -> None:  # pragma: no cover
+        pass
+
+    async with await factory.create_agent_client(
+        registration,
+        _request_handler,
+    ) as agent_client:
+        context = ActionContext(source_id, agent_client)
+        assert not context.is_agent_source()
+        assert context.is_user_source()
+
+        with pytest.raises(TypeError):
+            _ = context.source_handle

--- a/tests/exchange/client_test.py
+++ b/tests/exchange/client_test.py
@@ -98,7 +98,7 @@ async def test_client_get_factory(client: UserExchangeClient[Any]) -> None:
 @pytest.mark.asyncio
 async def test_client_get_handle(client: UserExchangeClient[Any]) -> None:
     registration = await client.register_agent(EmptyBehavior)
-    async with await client.get_handle(registration.agent_id):
+    async with client.get_handle(registration.agent_id):
         pass
 
 
@@ -107,7 +107,7 @@ async def test_client_get_handle_type_error(
     client: UserExchangeClient[Any],
 ) -> None:
     with pytest.raises(TypeError):
-        await client.get_handle(UserId.new())  # type: ignore[arg-type]
+        client.get_handle(UserId.new())  # type: ignore[arg-type]
 
 
 @pytest.mark.asyncio

--- a/tests/handle_test.py
+++ b/tests/handle_test.py
@@ -121,7 +121,7 @@ async def test_unbound_remote_handle_bind(
         match='An unbound handle has no client ID.',
     ):
         _ = handle.client_id
-    async with await handle.bind_to_client(exchange) as agent_bound:
+    async with handle.bind_to_client(exchange) as agent_bound:
         assert isinstance(agent_bound, RemoteHandle)
         assert isinstance(agent_bound.clone(), UnboundRemoteHandle)
 
@@ -194,7 +194,7 @@ async def test_agent_remote_handle_bind(
             ValueError,
             match='Cannot create handle to self.',
         ):
-            await client.get_handle(registration.agent_id)
+            client.get_handle(registration.agent_id)
 
 
 @pytest.mark.asyncio
@@ -273,7 +273,7 @@ async def test_client_remote_handle_wait_futures(
     await sleep_future
 
     # Create a new, non-closed handle to shutdown the agent
-    shutdown_handle = await manager.get_handle(handle.agent_id)
+    shutdown_handle = manager.get_handle(handle.agent_id)
     await shutdown_handle.shutdown()
     await manager.wait({handle.agent_id})
 
@@ -290,8 +290,6 @@ async def test_client_remote_handle_cancel_futures(
         await sleep_future
 
     # Create a new, non-closed handle to shutdown the agent
-    async with await manager.get_handle(
-        handle.agent_id,
-    ) as shutdown_handle:
+    async with manager.get_handle(handle.agent_id) as shutdown_handle:
         await shutdown_handle.shutdown()
     await manager.wait({handle.agent_id})


### PR DESCRIPTION
# Description
<!--- Describe your changes in detail --->

Action method decorators can now specify `context=True` to pass through context about the caller of the action.
```python
from academy.context import ActionContext

@action(context=True)
def foo(self, *, context: ActionContext) -> ...:
    context.source_id
    context.source_handle  # Only valid if source was an agent
```

### Fixes
<!--- List any issue numbers above that this PR addresses --->

- Fixes #97 

### Type of Change
<!--- Check which off the following types describe this PR --->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Refactoring (internal implementation changes)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update (no changes to the code)
- [ ] CI change (changes to CI workflows, packages, templates, etc.)
- [ ] Version changes (changes to the package or dependency versions)

## Testing
<!--- Please describe the test ran to verify changes --->

Added new tests.

## Pull Request Checklist

Please confirm the PR meets the following requirements.
- [x] Relevant tags are added (breaking, bug, dependencies, documentation, enhancement, refactor).
- [x] Code changes pass `pre-commit` (e.g., ruff, mypy, etc.).
- [x] Tests have been added to show the fix is effective or that the new feature works.
- [x] New and existing unit tests pass locally with the changes.
- [x] Docs have been updated and reviewed if relevant.
