### PR TITLE
Warn when action-decorated method name clashes with protected handle method

### DIFF
--- a/academy/behavior.py
+++ b/academy/behavior.py
@@ -5,6 +5,7 @@ import functools
 import inspect
 import logging
 import sys
+import warnings
 from collections.abc import Coroutine
 from collections.abc import Generator
 from datetime import timedelta
@@ -307,6 +308,7 @@ def action(method: ActionMethod[P, R]) -> ActionMethod[P, R]: ...
 @overload
 def action(
     *,
+    allow_protected_name: bool = False,
     context: bool = False,
 ) -> Callable[[ActionMethod[P, R]], ActionMethod[P, R]]: ...
 
@@ -314,6 +316,7 @@ def action(
 def action(
     method: ActionMethod[P, R] | None = None,
     *,
+    allow_protected_name: bool = False,
     context: bool = False,
 ) -> ActionMethod[P, R] | Callable[[ActionMethod[P, R]], ActionMethod[P, R]]:
     """Decorator that annotates a method of a behavior as an action.
@@ -338,25 +341,40 @@ def action(
                 ...
         ```
 
+    Warning:
+        A warning will be emitted if the decorated method's name clashed
+        with a method of [`Handle`][academy.handle.Handle] because it would
+        not be possible to invoke this action remotely via attribute
+        lookup on a handle. This warning can be suppressed with
+        `allow_protected_name=True`, and the action must be invoked via
+        [`Handle.action()`][academy.handle.Handle.action].
+
     Args:
         method: Method to decorate as an action.
+        allow_protected_name: Allow decorating a method as an action when
+            the name of the method clashes with a protected method name of
+            [`Handle`][academy.handle.Handle]. This flag silences the
+            emitted warning.
         context: Specify that the action method expects a context argument.
             The `context` will be provided at runtime as a keyword argument.
 
     Raises:
-        AttributeError: If the name of the decorated method clashes with
-            a method defined on [`Handle`][academy.handle.Handle].
         TypeError: If `context=True` and the method does not have a parameter
             named `context` or if `context` is a positional only argument.
     """
 
     def decorator(method_: ActionMethod[P, R]) -> ActionMethod[P, R]:
-        if method_.__name__ in _get_handle_protected_methods():
-            raise AttributeError(
-                f'The method name "{method_.__name__}" clashes with the '
-                'name of a protected method of Handle. Rename this action '
-                'method to avoid ambiguity when remotely invoking it via '
-                'a handle.',
+        if (
+            not allow_protected_name
+            and method_.__name__ in _get_handle_protected_methods()
+        ):
+            warnings.warn(
+                f'The name of the decorated method is "{method_.__name__}" '
+                'which clashes with a protected method of Handle. '
+                'Rename the decorated method to avoid ambiguity when remotely '
+                'invoking it via a handle.',
+                UserWarning,
+                stacklevel=3,
             )
         # Typing the requirement that if context=True then params P should
         # contain a keyword argument named "context" is not easily annotated

--- a/tests/behavior_test.py
+++ b/tests/behavior_test.py
@@ -217,27 +217,34 @@ def test_behavior_action_decorator_usage_error() -> None:
         action(context=True)(_TestBehavior.pos_only)
 
 
+def test_behavior_action_decorator_name_clash_ok() -> None:
+    class _TestBehavior(Behavior):
+        async def ping(self) -> None: ...
+
+    action(allow_protected_name=True)(_TestBehavior.ping)
+
+
 def test_behavior_action_decorator_name_clash_error() -> None:
     class _TestBehavior(Behavior):
         async def action(self) -> None: ...
         async def ping(self) -> None: ...
         async def shutdown(self) -> None: ...
 
-    with pytest.raises(
-        AttributeError,
-        match='The method name "action" clashes with the name of a protected',
+    with pytest.warns(
+        UserWarning,
+        match='The name of the decorated method is "action" which clashes',
     ):
         action(_TestBehavior.action)
 
-    with pytest.raises(
-        AttributeError,
-        match='The method name "ping" clashes with the name of a protected',
+    with pytest.warns(
+        UserWarning,
+        match='The name of the decorated method is "ping" which clashes',
     ):
         action(_TestBehavior.ping)
 
-    with pytest.raises(
-        AttributeError,
-        match='The method name "shutdown" clashes with the name of a',
+    with pytest.warns(
+        UserWarning,
+        match='The name of the decorated method is "shutdown" which clashes',
     ):
         action(_TestBehavior.shutdown)
 

--- a/tests/behavior_test.py
+++ b/tests/behavior_test.py
@@ -184,8 +184,7 @@ async def test_behavior_timer() -> None:
     await asyncio.wait_for(task, timeout=TEST_THREAD_JOIN_TIMEOUT)
 
 
-@pytest.mark.asyncio
-async def test_behavior_action_decorator_usage_ok() -> None:
+def test_behavior_action_decorator_usage_ok() -> None:
     class _TestBehavior(Behavior):
         @action
         async def action1(self) -> None: ...
@@ -200,8 +199,7 @@ async def test_behavior_action_decorator_usage_ok() -> None:
     assert len(behavior.behavior_actions()) == 3  # noqa: PLR2004
 
 
-@pytest.mark.asyncio
-async def test_behavior_action_decorator_usage_error() -> None:
+def test_behavior_action_decorator_usage_error() -> None:
     class _TestBehavior(Behavior):
         async def missing_arg(self) -> None: ...
         async def pos_only(self, context: ActionContext, /) -> None: ...
@@ -217,6 +215,31 @@ async def test_behavior_action_decorator_usage_error() -> None:
         match='The "context" argument to action method "pos_only"',
     ):
         action(context=True)(_TestBehavior.pos_only)
+
+
+def test_behavior_action_decorator_name_clash_error() -> None:
+    class _TestBehavior(Behavior):
+        async def action(self) -> None: ...
+        async def ping(self) -> None: ...
+        async def shutdown(self) -> None: ...
+
+    with pytest.raises(
+        AttributeError,
+        match='The method name "action" clashes with the name of a protected',
+    ):
+        action(_TestBehavior.action)
+
+    with pytest.raises(
+        AttributeError,
+        match='The method name "ping" clashes with the name of a protected',
+    ):
+        action(_TestBehavior.ping)
+
+    with pytest.raises(
+        AttributeError,
+        match='The method name "shutdown" clashes with the name of a',
+    ):
+        action(_TestBehavior.shutdown)
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
# Description
<!--- Describe your changes in detail --->

The `@action` decorator now warns the user if the name of the decorated method clashes with the name of a "protected" method of `Handle` (i.e., ping, action, shutdown). This prevents users from not being able to invoke the action because the method defined on `Handle` gets called instead.

The `@action` decorator now has an optional flag to suppress the error, but invoking the action will require a manual call (i.e., `handle.action('shutdown')` instead of `handle.shutdown()`).

### Fixes
<!--- List any issue numbers above that this PR addresses --->

- Fixes #71

### Type of Change
<!--- Check which off the following types describe this PR --->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Refactoring (internal implementation changes)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update (no changes to the code)
- [ ] CI change (changes to CI workflows, packages, templates, etc.)
- [ ] Version changes (changes to the package or dependency versions)

## Testing
<!--- Please describe the test ran to verify changes --->

Added a new test.

## Pull Request Checklist

Please confirm the PR meets the following requirements.
- [x] Relevant tags are added (breaking, bug, dependencies, documentation, enhancement, refactor).
- [x] Code changes pass `pre-commit` (e.g., ruff, mypy, etc.).
- [x] Tests have been added to show the fix is effective or that the new feature works.
- [x] New and existing unit tests pass locally with the changes.
- [x] Docs have been updated and reviewed if relevant.
