### PR TITLE
Allow users to specify termination behavior when requesting agent shutdown

### DIFF
--- a/academy/handle.py
+++ b/academy/handle.py
@@ -141,10 +141,14 @@ class Handle(Protocol[BehaviorT]):
         """
         ...
 
-    async def shutdown(self) -> None:
+    async def shutdown(self, *, terminate: bool | None = None) -> None:
         """Instruct the agent to shutdown.
 
         This is non-blocking and will only send the message.
+
+        Args:
+            terminate: Override the termination behavior of the agent defined
+                in the [`AgentRunConfig`][academy.agent.AgentRunConfig].
 
         Raises:
             HandleClosedError: If the handle was closed.
@@ -311,10 +315,14 @@ class ProxyHandle(Generic[BehaviorT]):
             raise HandleClosedError(self.agent_id, self.client_id)
         return 0
 
-    async def shutdown(self) -> None:
+    async def shutdown(self, *, terminate: bool | None = None) -> None:
         """Instruct the agent to shutdown.
 
         This is non-blocking and will only send the message.
+
+        Args:
+            terminate: Override the termination behavior of the agent defined
+                in the [`AgentRunConfig`][academy.agent.AgentRunConfig].
 
         Raises:
             HandleClosedError: If the handle was closed.
@@ -326,7 +334,7 @@ class ProxyHandle(Generic[BehaviorT]):
             raise MailboxClosedError(self.agent_id)
         elif self._handle_closed:
             raise HandleClosedError(self.agent_id, self.client_id)
-        self._agent_closed = True
+        self._agent_closed = True if terminate is None else terminate
 
 
 class UnboundRemoteHandle(Generic[BehaviorT]):
@@ -398,7 +406,7 @@ class UnboundRemoteHandle(Generic[BehaviorT]):
         """Raises [`HandleNotBoundError`][academy.exception.HandleNotBoundError]."""  # noqa: E501
         raise HandleNotBoundError(self.agent_id)
 
-    async def shutdown(self) -> None:
+    async def shutdown(self, *, terminate: bool | None = None) -> None:
         """Raises [`HandleNotBoundError`][academy.exception.HandleNotBoundError]."""  # noqa: E501
         raise HandleNotBoundError(self.agent_id)
 
@@ -623,10 +631,14 @@ class RemoteHandle(Generic[BehaviorT]):
         )
         return elapsed
 
-    async def shutdown(self) -> None:
+    async def shutdown(self, *, terminate: bool | None = None) -> None:
         """Instruct the agent to shutdown.
 
         This is non-blocking and will only send the message.
+
+        Args:
+            terminate: Override the termination behavior of the agent defined
+                in the [`AgentRunConfig`][academy.agent.AgentRunConfig].
 
         Raises:
             HandleClosedError: If the handle was closed.
@@ -641,6 +653,7 @@ class RemoteHandle(Generic[BehaviorT]):
             src=self.client_id,
             dest=self.agent_id,
             label=self.handle_id,
+            terminate=terminate,
         )
         await self.exchange.send(request)
         logger.debug(

--- a/academy/manager.py
+++ b/academy/manager.py
@@ -477,6 +477,7 @@ class Manager(Generic[ExchangeTransportT], NoPickleMixin):
         *,
         blocking: bool = True,
         raise_error: bool = True,
+        terminate: bool | None = None,
         timeout: float | None = None,
     ) -> None:
         """Shutdown a launched agent.
@@ -486,6 +487,8 @@ class Manager(Generic[ExchangeTransportT], NoPickleMixin):
             blocking: Wait for the agent to exit before returning.
             raise_error: Raise the error returned by the agent if
                 `blocking=True`.
+            terminate: Override the termination behavior of the agent defined
+                in the [`AgentRunConfig`][academy.agent.AgentRunConfig].
             timeout: Optional timeout is seconds when `blocking=True`.
 
         Raises:
@@ -502,7 +505,7 @@ class Manager(Generic[ExchangeTransportT], NoPickleMixin):
 
         handle = self.get_handle(agent_id)
         with contextlib.suppress(MailboxClosedError):
-            await handle.shutdown()
+            await handle.shutdown(terminate=terminate)
 
         if blocking:
             await self.wait(

--- a/academy/message.py
+++ b/academy/message.py
@@ -290,6 +290,7 @@ class ShutdownRequest(BaseMessage):
     """Agent shutdown request message."""
 
     kind: Literal['shutdown-request'] = Field('shutdown-request', repr=False)
+    terminate: Optional[bool] = None  # noqa: UP045
 
     @field_validator('dest', mode='after')
     @classmethod

--- a/docs/concepts.md
+++ b/docs/concepts.md
@@ -67,9 +67,9 @@ Mailboxes are managed by an exchange, and the [`ExchangeClient`][academy.exchang
 An [`ExchangeFactory`][academy.exchange.ExchangeFactory] is used to register a new entity with the exchange and create a client that the entity can use for communicating with the exchange.
 Registering an entity involves creating a unique ID for the entity, which is also the address of its mailbox, and initializing that mailbox within the exchange.
 
-A mailbox has two states: open and closed.
-Open indicates that the entity is accepting messages, even if, for example, an agent has not yet started or is temporarily offline.
-Closed indicates permanent termination of the entity and will cause [`MailboxClosedError`][academy.exception.MailboxClosedError] to be raised by subsequent send or receive operations to that mailbox.
+A mailbox has two states: active and terminated.
+Active indicates that the entity's mailbox is accepting messages, even if, for example, an agent has not yet started or is temporarily offline.
+Terminated indicates permanent termination of the entity and will cause [`MailboxClosedError`][academy.exception.MailboxClosedError] to be raised by subsequent send or receive operations to that mailbox.
 
 Academy provides many exchange implementations for different scenarios, such as:
 


### PR DESCRIPTION
# Description
<!--- Describe your changes in detail --->

Allow users to specify termination behavior when requesting agent shutdown, overriding the default behavior of the agent (defined in its run config). This is done via the `terminate` flag to `Manager.shutdown()` and `Handle.shutdown()` which defaults to `None` indicating the agent should use its own default settings.

### Fixes
<!--- List any issue numbers above that this PR addresses --->

- Fixes #88

### Type of Change
<!--- Check which off the following types describe this PR --->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Refactoring (internal implementation changes)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update (no changes to the code)
- [ ] CI change (changes to CI workflows, packages, templates, etc.)
- [ ] Version changes (changes to the package or dependency versions)

## Testing
<!--- Please describe the test ran to verify changes --->

Added a test.

## Pull Request Checklist

Please confirm the PR meets the following requirements.
- [x] Relevant tags are added (breaking, bug, dependencies, documentation, enhancement, refactor).
- [x] Code changes pass `pre-commit` (e.g., ruff, mypy, etc.).
- [x] Tests have been added to show the fix is effective or that the new feature works.
- [x] New and existing unit tests pass locally with the changes.
- [x] Docs have been updated and reviewed if relevant.
