### PR TITLE
Cancel running actions when an agent is shutdown

### DIFF
--- a/academy/exception.py
+++ b/academy/exception.py
@@ -9,6 +9,17 @@ from academy.identifier import EntityId
 from academy.identifier import UserId
 
 
+class ActionCancelledError(Exception):
+    """Action was cancelled by the agent.
+
+    This often happens when an agent is shutdown mid-action execution and
+    configured to cancel running actions.
+    """
+
+    def __init__(self, name: str) -> None:
+        super().__init__(f'Action "{name}" was cancelled by the agent.')
+
+
 class AgentNotInitializedError(Exception):
     """Agent runtime context has not been initialized.
 


### PR DESCRIPTION
# Description
<!--- Describe your changes in detail --->

By default, running actions are now cancelled when an agent is shutdown. The `_execute_action` task has been updated to catch task cancellation to reply to the requester with a new `ActionCancelledError`.

The previous behavior, where the agent blocks until all pending actions have completed, is still available via `RuntimeConfig.cancel_actions_on_shutdown = False`. The change in behavior should reduce the likelihood of agent shutdown deadlocking on pending actions.

### Fixes N/A
<!--- List any issue numbers above that this PR addresses --->

### Type of Change
<!--- Check which off the following types describe this PR --->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Refactoring (internal implementation changes)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update (no changes to the code)
- [ ] CI change (changes to CI workflows, packages, templates, etc.)
- [ ] Version changes (changes to the package or dependency versions)

## Testing
<!--- Please describe the test ran to verify changes --->

N/A

## Pull Request Checklist

Please confirm the PR meets the following requirements.
- [x] Relevant tags are added (breaking, bug, dependencies, documentation, enhancement, refactor).
- [x] Code changes pass `pre-commit` (e.g., ruff, mypy, etc.).
- [x] Tests have been added to show the fix is effective or that the new feature works.
- [x] New and existing unit tests pass locally with the changes.
- [x] Docs have been updated and reviewed if relevant.
