### PR TITLE
Change terminate semantics to cancel pending requests

### DIFF
--- a/academy/exception.py
+++ b/academy/exception.py
@@ -74,6 +74,13 @@ class MailboxTerminatedError(ExchangeError):
         super().__init__(f'Mailbox for {uid} has been terminated.')
         self.uid = uid
 
+    def __reduce__(self) -> Any:
+        # BaseException implements __reduce__ as
+        #     return type(self), self.args
+        # where args will contain the message passed to super().__init__
+        # rather than uid so it must be customized.
+        return type(self), (self.uid,)
+
 
 class AgentTerminatedError(MailboxTerminatedError):
     """Agent mailbox is terminated and cannot send or receive messages."""

--- a/academy/exchange/local.py
+++ b/academy/exchange/local.py
@@ -13,7 +13,9 @@ if sys.version_info >= (3, 11):  # pragma: >=3.11 cover
 else:  # pragma: <3.11 cover
     from typing_extensions import Self
 
+from aiologic import Lock
 from culsans import AsyncQueue
+from culsans import AsyncQueueEmpty as QueueEmpty
 from culsans import AsyncQueueShutDown as QueueShutDown
 from culsans import Queue
 
@@ -22,6 +24,7 @@ from academy.agent import AgentT
 from academy.exception import BadEntityIdError
 from academy.exception import MailboxTerminatedError
 from academy.exchange import ExchangeFactory
+from academy.exchange.transport import _respond_pending_requests_on_terminate
 from academy.exchange.transport import ExchangeTransportMixin
 from academy.exchange.transport import MailboxStatus
 from academy.identifier import AgentId
@@ -43,6 +46,7 @@ class _LocalExchangeState(NoPickleMixin):
 
     def __init__(self) -> None:
         self.queues: dict[EntityId, AsyncQueue[Message]] = {}
+        self.locks: dict[EntityId, Lock] = {}
         self.agents: dict[AgentId[Any], type[Agent]] = {}
 
 
@@ -89,6 +93,7 @@ class LocalExchangeTransport(ExchangeTransportMixin, NoPickleMixin):
         if mailbox_id is None:
             mailbox_id = UserId.new(name=name)
             state.queues[mailbox_id] = Queue().async_q
+            state.locks[mailbox_id] = Lock()
             logger.info('Registered %s in exchange', mailbox_id)
         return cls(mailbox_id, state)
 
@@ -139,6 +144,7 @@ class LocalExchangeTransport(ExchangeTransportMixin, NoPickleMixin):
     ) -> LocalAgentRegistration[AgentT]:
         aid: AgentId[AgentT] = AgentId.new(name=name)
         self._state.queues[aid] = Queue().async_q
+        self._state.locks[aid] = Lock()
         self._state.agents[aid] = agent
         return LocalAgentRegistration(agent_id=aid)
 
@@ -146,21 +152,32 @@ class LocalExchangeTransport(ExchangeTransportMixin, NoPickleMixin):
         queue = self._state.queues.get(message.dest, None)
         if queue is None:
             raise BadEntityIdError(message.dest)
-        try:
-            await queue.put(message)
-        except QueueShutDown:
-            raise MailboxTerminatedError(message.dest) from None
+        async with self._state.locks[message.dest]:
+            try:
+                await queue.put(message)
+            except QueueShutDown:
+                raise MailboxTerminatedError(message.dest) from None
 
     async def status(self, uid: EntityId) -> MailboxStatus:
         if uid not in self._state.queues:
             return MailboxStatus.MISSING
-        if self._state.queues[uid].is_shutdown:
-            return MailboxStatus.TERMINATED
-        return MailboxStatus.ACTIVE
+        async with self._state.locks[uid]:
+            if self._state.queues[uid].is_shutdown:
+                return MailboxStatus.TERMINATED
+            return MailboxStatus.ACTIVE
 
     async def terminate(self, uid: EntityId) -> None:
         queue = self._state.queues.get(uid, None)
-        if queue is not None and not queue.is_shutdown:
+        if queue is None:
+            return
+
+        async with self._state.locks[uid]:
+            if queue.is_shutdown:
+                return
+
+            messages = await _drain_queue(queue)
+            await _respond_pending_requests_on_terminate(messages, self)
+
             queue.shutdown(immediate=True)
             if isinstance(uid, AgentId):
                 self._state.agents.pop(uid, None)
@@ -195,3 +212,18 @@ class LocalExchangeFactory(
             name=name,
             state=self._state,
         )
+
+
+async def _drain_queue(queue: AsyncQueue[Message]) -> list[Message]:
+    items: list[Message] = []
+
+    while True:
+        try:
+            item = queue.get_nowait()
+        except (QueueShutDown, QueueEmpty):
+            break
+        else:
+            items.append(item)
+            queue.task_done()
+
+    return items

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -24,6 +24,7 @@ classifiers = [
 ]
 dependencies = [
     "aiohttp",
+    "aiologic",
     "click!=8.1.4",
     "culsans",
     "globus_sdk>=3.46,<4",

--- a/tests/exchange/cloud/server_test.py
+++ b/tests/exchange/cloud/server_test.py
@@ -124,16 +124,16 @@ async def test_mailbox_manager_create_close() -> None:
     uid = UserId.new()
     # Should do nothing since mailbox doesn't exist
     await manager.terminate(user_id, uid)
-    assert manager.check_mailbox(user_id, uid) == MailboxStatus.MISSING
+    assert await manager.check_mailbox(user_id, uid) == MailboxStatus.MISSING
     manager.create_mailbox(user_id, uid)
-    assert manager.check_mailbox(user_id, uid) == MailboxStatus.ACTIVE
+    assert await manager.check_mailbox(user_id, uid) == MailboxStatus.ACTIVE
     manager.create_mailbox(user_id, uid)  # Idempotent check
 
     bad_user = str(uuid.uuid4())  # Authentication check
     with pytest.raises(ForbiddenError):
         manager.create_mailbox(bad_user, uid)
     with pytest.raises(ForbiddenError):
-        manager.check_mailbox(bad_user, uid)
+        await manager.check_mailbox(bad_user, uid)
     with pytest.raises(ForbiddenError):
         await manager.terminate(bad_user, uid)
 


### PR DESCRIPTION
# Description
<!--- Describe your changes in detail --->

Changes the terminate semantics to cancel pending requests messages by reading all messages in a mailbox that is to be terminated and then replying to any request messages with a `MailboxTerminatedError`. Exchange transport implementations should terminate the mailbox before doing so, to avoid new message writes to the mailbox.

For the Redis/Hybrid exchange, this new functionality required using `lrange` so I needed to rework the mock redis client a bit.

The implementation of this new behavior is somewhat flakey for the Hybrid exchange as we can cancel pending messages in Redis, but not necessarily those sent directly. The transports do maintain a local queue of pending messages that could be cancelled, but this required a bit of extra logic to catch termination events in a few places and invalidate the queues. Realistically, I think the hybrid exchange may just need to be refactored first.

### Fixes
<!--- List any issue numbers above that this PR addresses --->

- Fixes #90

### Type of Change
<!--- Check which off the following types describe this PR --->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Refactoring (internal implementation changes)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update (no changes to the code)
- [ ] CI change (changes to CI workflows, packages, templates, etc.)
- [ ] Version changes (changes to the package or dependency versions)

## Testing
<!--- Please describe the test ran to verify changes --->

Added new tests.

## Pull Request Checklist

Please confirm the PR meets the following requirements.
- [x] Relevant tags are added (breaking, bug, dependencies, documentation, enhancement, refactor).
- [x] Code changes pass `pre-commit` (e.g., ruff, mypy, etc.).
- [x] Tests have been added to show the fix is effective or that the new feature works.
- [x] New and existing unit tests pass locally with the changes.
- [x] Docs have been updated and reviewed if relevant.
