### PR TITLE
New interface for http exchange

### DIFF
--- a/academy/exchange/cloud/__init__.py
+++ b/academy/exchange/cloud/__init__.py
@@ -1,0 +1,9 @@
+from __future__ import annotations
+
+from academy.exchange.cloud.client import HttpExchangeFactory
+from academy.exchange.cloud.client import HttpExchangeTransport
+
+__all__ = [
+    'HttpExchangeFactory',
+    'HttpExchangeTransport',
+]

--- a/academy/exchange/cloud/server.py
+++ b/academy/exchange/cloud/server.py
@@ -9,7 +9,9 @@ Connect to the exchange through the client.
 ```python
 from academy.exchange.cloud.client import HttpExchangeFactory
 
-with HttpExchangeFactory('localhost', 1234).create_user_client() as exchange:
+with HttpExchangeFactory(
+    'http://localhost:1234'
+).create_user_client() as exchange:
     aid, agent_info = exchange.register_agent()
     ...
 ```

--- a/testing/fixture.py
+++ b/testing/fixture.py
@@ -27,7 +27,8 @@ async def http_exchange_factory(
     http_exchange_server: tuple[str, int],
 ) -> HttpExchangeFactory:
     host, port = http_exchange_server
-    return HttpExchangeFactory(host, port)
+    url = f'http://{host}:{port}'
+    return HttpExchangeFactory(url)
 
 
 @pytest.fixture
@@ -69,7 +70,8 @@ async def get_factory(
     ) -> ExchangeFactory[Any]:
         if factory_type is HttpExchangeFactory:
             host, port = http_exchange_server
-            return HttpExchangeFactory(host, port)
+            url = f'http://{host}:{port}'
+            return HttpExchangeFactory(url)
         elif factory_type is HybridExchangeFactory:
             return HybridExchangeFactory(redis_host='localhost', redis_port=0)
         elif factory_type is RedisExchangeFactory:

--- a/tests/exchange/cloud/client_test.py
+++ b/tests/exchange/cloud/client_test.py
@@ -32,7 +32,8 @@ def test_factory_serialize(
 @pytest.mark.asyncio
 async def test_recv_timeout(http_exchange_server: tuple[str, int]) -> None:
     host, port = http_exchange_server
-    factory = HttpExchangeFactory(host, port)
+    url = f'http://{host}:{port}'
+    factory = HttpExchangeFactory(url)
 
     class MockResponse:
         status = StatusCode.TIMEOUT.value
@@ -59,8 +60,9 @@ async def test_additional_headers(
     http_exchange_server: tuple[str, int],
 ) -> None:
     host, port = http_exchange_server
+    url = f'http://{host}:{port}'
     headers = {'Authorization': 'fake auth'}
-    factory = HttpExchangeFactory(host, port, headers)
+    factory = HttpExchangeFactory(url, additional_headers=headers)
     async with await factory._create_transport() as transport:
         assert isinstance(transport, HttpExchangeTransport)
         assert 'Authorization' in transport._session.headers

--- a/tests/exchange/cloud/client_test.py
+++ b/tests/exchange/cloud/client_test.py
@@ -11,9 +11,9 @@ from academy.exception import BadEntityIdError
 from academy.exception import ForbiddenError
 from academy.exception import MailboxTerminatedError
 from academy.exception import UnauthorizedError
+from academy.exchange.cloud import HttpExchangeFactory
+from academy.exchange.cloud import HttpExchangeTransport
 from academy.exchange.cloud.client import _raise_for_status
-from academy.exchange.cloud.client import HttpExchangeFactory
-from academy.exchange.cloud.client import HttpExchangeTransport
 from academy.exchange.cloud.client import spawn_http_exchange
 from academy.exchange.cloud.server import StatusCode
 from academy.identifier import UserId

--- a/tests/exchange/cloud/server_test.py
+++ b/tests/exchange/cloud/server_test.py
@@ -71,9 +71,7 @@ def test_server_run() -> None:
     while True:
         try:
             client = HttpExchangeFactory(
-                config.host,
-                config.port,
-                scheme='http',
+                f'http://{config.host}:{config.port}/',
             ).create_user_client()
         except OSError:  # pragma: no cover
             time.sleep(0.01)
@@ -102,9 +100,7 @@ def test_server_run_ssl(ssl_context: SSLContextFixture) -> None:
     while True:
         try:
             client = HttpExchangeFactory(
-                config.host,
-                config.port,
-                scheme='https',
+                f'https://{config.host}:{config.port}/',
                 ssl_verify=False,
             ).create_user_client()
         except OSError:  # pragma: no cover

--- a/tests/exchange/cloud/server_test.py
+++ b/tests/exchange/cloud/server_test.py
@@ -19,7 +19,7 @@ from aiohttp.web import Request
 from academy.exception import BadEntityIdError
 from academy.exception import MailboxTerminatedError
 from academy.exchange import MailboxStatus
-from academy.exchange.cloud.client import HttpExchangeFactory
+from academy.exchange.cloud import HttpExchangeFactory
 from academy.exchange.cloud.config import ExchangeAuthConfig
 from academy.exchange.cloud.config import ExchangeServingConfig
 from academy.exchange.cloud.exceptions import ForbiddenError


### PR DESCRIPTION
# Description
Change the interface for the http exchange to make it more user friendly. To connect to the hosted exchange before, you had to pass 4 different arguments and manually manage the authentication. Now you can call `HttpExchangeFactory(url, auth_method='globus')`


### Type of Change
- [x] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Pull Request Checklist

Please confirm the PR meets the following requirements.
- [x] Relevant tags are added (breaking, bug, dependencies, documentation, enhancement, refactor).
- [x] Code changes pass `pre-commit` (e.g., ruff, mypy, etc.).
- [x] Tests have been added to show the fix is effective or that the new feature works.
- [x] New and existing unit tests pass locally with the changes.
- [x] Docs have been updated and reviewed if relevant.
