### PR TITLE
Lazily deserialize arguments in `ActionRequest` messages

### DIFF
--- a/academy/exchange/proxystore.py
+++ b/academy/exchange/proxystore.py
@@ -116,7 +116,9 @@ class ProxyStoreExchangeTransport(
     async def recv(self, timeout: float | None = None) -> Message:
         message = await self.transport.recv(timeout)
         if self.resolve_async and isinstance(message, ActionRequest):
-            for arg in (*message.pargs, *message.kargs.values()):
+            args = message.get_args()
+            kwargs = message.get_kwargs()
+            for arg in (*args, *kwargs.values()):
                 if type(arg) is Proxy:
                     resolve_async(arg)
         elif (
@@ -138,12 +140,12 @@ class ProxyStoreExchangeTransport(
     async def send(self, message: Message) -> None:
         if isinstance(message, ActionRequest):
             message.pargs = _proxy_iterable(
-                message.pargs,
+                message.get_args(),
                 self.store,
                 self.should_proxy,
             )
             message.kargs = _proxy_mapping(
-                message.kargs,
+                message.get_kwargs(),
                 self.store,
                 self.should_proxy,
             )

--- a/academy/message.py
+++ b/academy/message.py
@@ -132,6 +132,8 @@ class ActionRequest(BaseMessage):
 
     @field_serializer('pargs', 'kargs', when_used='json')
     def _pickle_and_encode_obj(self, obj: Any) -> str:
+        if isinstance(obj, str):  # pragma: no cover
+            return obj
         raw = pickle.dumps(obj)
         return base64.b64encode(raw).decode('utf-8')
 

--- a/academy/message.py
+++ b/academy/message.py
@@ -14,6 +14,7 @@ from pydantic import ConfigDict
 from pydantic import Field
 from pydantic import field_serializer
 from pydantic import field_validator
+from pydantic import SkipValidation
 from pydantic import TypeAdapter
 
 from academy.identifier import AgentId
@@ -105,27 +106,52 @@ class ActionRequest(BaseMessage):
     """
 
     action: str = Field(description='Name of the requested action.')
-    pargs: tuple[Any, ...] = Field(
+    pargs: SkipValidation[tuple[Any, ...]] = Field(
         default_factory=tuple,
         description='Positional arguments to the action method.',
     )
-    kargs: dict[str, Any] = Field(
+    kargs: SkipValidation[dict[str, Any]] = Field(
         default_factory=dict,
         description='Keyword arguments to the action method.',
     )
     kind: Literal['action-request'] = Field('action-request', repr=False)
+
+    def __eq__(self, other: object, /) -> bool:
+        if not isinstance(other, ActionRequest):
+            return False
+        return (
+            self.tag == other.tag
+            and self.src == other.src
+            and self.dest == other.dest
+            and self.label == other.label
+            and self.action == other.action
+        )
+
+    def __hash__(self) -> int:
+        return hash((type(self), self.tag))
 
     @field_serializer('pargs', 'kargs', when_used='json')
     def _pickle_and_encode_obj(self, obj: Any) -> str:
         raw = pickle.dumps(obj)
         return base64.b64encode(raw).decode('utf-8')
 
-    @field_validator('pargs', 'kargs', mode='before')
-    @classmethod
-    def _decode_pickled_obj(cls, obj: Any) -> Any:
-        if not isinstance(obj, str):
-            return obj
-        return pickle.loads(base64.b64decode(obj))
+    def get_args(self) -> tuple[Any, ...]:
+        """Get the positional arguments.
+
+        Lazy deserializes the positional arguments and caches the result.
+        """
+        if isinstance(self.pargs, str):
+            self.pargs = pickle.loads(base64.b64decode(self.pargs))
+        return self.pargs
+
+    def get_kwargs(self) -> dict[str, Any]:
+        """Get the keyword arguments.
+
+        Lazy deserializes the keyword arguments and caches the result.
+        """
+        if isinstance(self.kargs, str):
+            self.kargs = pickle.loads(base64.b64decode(self.kargs))
+        return self.kargs
 
     def error(self, exception: Exception) -> ActionResponse:
         """Construct an error response to action request.

--- a/academy/runtime.py
+++ b/academy/runtime.py
@@ -156,8 +156,8 @@ class Runtime(Generic[AgentT], NoPickleMixin):
             result = await self.action(
                 request.action,
                 request.src,
-                args=request.pargs,
-                kwargs=request.kargs,
+                args=request.get_args(),
+                kwargs=request.get_kwargs(),
             )
         except asyncio.CancelledError:
             exception = ActionCancelledError(request.action)

--- a/tests/exchange/proxystore_test.py
+++ b/tests/exchange/proxystore_test.py
@@ -85,7 +85,7 @@ async def test_wrap_basic_transport_functionality(
         assert isinstance(received, ActionRequest)
         assert request.tag == received.tag
 
-        for old, new in zip(request.pargs, received.pargs):
+        for old, new in zip(request.get_args(), received.get_args()):
             assert (type(new) is Proxy) == should_proxy(old)
             # will resolve the proxy if it exists
             assert old == new

--- a/tests/message_test.py
+++ b/tests/message_test.py
@@ -58,6 +58,7 @@ def test_message_representations(message: Message) -> None:
     recreated = BaseMessage.model_from_json(jsoned)
     assert message == recreated
     assert hash(message) == hash(recreated)
+    assert message != object()
     pickled = message.model_serialize()
     recreated = BaseMessage.model_deserialize(pickled)
     assert message == recreated
@@ -93,6 +94,28 @@ def test_create_response_message(request_: RequestMessage) -> None:
     response = request_.error(exception)
     assert isinstance(response, get_args(ResponseMessage))
     assert response.exception == exception
+
+
+def test_action_request_lazy_deserialize() -> None:
+    request = ActionRequest(
+        src=_src,
+        dest=_dest,
+        action='foo',
+        pargs=('bar',),
+        kargs={'foo': 'bar'},
+    )
+
+    json = request.model_dump_json()
+    reconstructed = BaseMessage.model_from_json(json)
+    assert isinstance(reconstructed, ActionRequest)
+    assert isinstance(reconstructed.pargs, str)
+    assert isinstance(reconstructed.kargs, str)
+
+    reconstructed.get_args()
+    reconstructed.get_kwargs()
+
+    assert isinstance(reconstructed.pargs, tuple)
+    assert isinstance(reconstructed.kargs, dict)
 
 
 @pytest.mark.parametrize(

--- a/tests/message_test.py
+++ b/tests/message_test.py
@@ -107,6 +107,7 @@ def test_action_request_lazy_deserialize() -> None:
 
     json = request.model_dump_json()
     reconstructed = BaseMessage.model_from_json(json)
+
     assert isinstance(reconstructed, ActionRequest)
     assert isinstance(reconstructed.pargs, str)
     assert isinstance(reconstructed.kargs, str)


### PR DESCRIPTION
# Description
<!--- Describe your changes in detail --->

Lazily deserialize arguments in `ActionRequest` messages.

Note that this only works when the message is JSON serialized, so I'm not going to mark #155 as closed while we work on a more permanent solution which separates message body and headers so the body can be lazily deserialized.

### Fixes
<!--- List any issue numbers above that this PR addresses --->

Partially addresses #155

### Type of Change
<!--- Check which off the following types describe this PR --->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Refactoring (internal implementation changes)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update (no changes to the code)
- [ ] CI change (changes to CI workflows, packages, templates, etc.)
- [ ] Version changes (changes to the package or dependency versions)

## Testing
<!--- Please describe the test ran to verify changes --->

Added a unit test for lazy deserialization. 

## Pull Request Checklist

Please confirm the PR meets the following requirements.
- [x] Relevant tags are added (breaking, bug, dependencies, documentation, enhancement, refactor).
- [x] Code changes pass `pre-commit` (e.g., ruff, mypy, etc.).
- [x] Tests have been added to show the fix is effective or that the new feature works.
- [x] New and existing unit tests pass locally with the changes.
- [x] Docs have been updated and reviewed if relevant.
