### PR TITLE
Refactor messages to use header/body model

### DIFF
--- a/academy/exchange/cloud/client.py
+++ b/academy/exchange/cloud/client.py
@@ -38,7 +38,6 @@ from academy.exchange.transport import MailboxStatus
 from academy.identifier import AgentId
 from academy.identifier import EntityId
 from academy.identifier import UserId
-from academy.message import BaseMessage
 from academy.message import Message
 from academy.serialize import NoPickleMixin
 from academy.socket import wait_connection
@@ -162,7 +161,7 @@ class HttpExchangeTransport(ExchangeTransportMixin, NoPickleMixin):
             ssl_verify=self._info.ssl_verify,
         )
 
-    async def recv(self, timeout: float | None = None) -> Message:
+    async def recv(self, timeout: float | None = None) -> Message[Any]:
         try:
             async with self._session.get(
                 self._message_url,
@@ -181,7 +180,7 @@ class HttpExchangeTransport(ExchangeTransportMixin, NoPickleMixin):
                 f'Failed to receive response in {timeout} seconds.',
             ) from e
 
-        return BaseMessage.model_from_json(message_raw)
+        return Message.model_validate_json(message_raw)
 
     async def register_agent(
         self,
@@ -200,7 +199,7 @@ class HttpExchangeTransport(ExchangeTransportMixin, NoPickleMixin):
             _raise_for_status(response, self.mailbox_id, aid)
         return HttpAgentRegistration(agent_id=aid)
 
-    async def send(self, message: Message) -> None:
+    async def send(self, message: Message[Any]) -> None:
         async with self._session.put(
             self._message_url,
             json={'message': message.model_dump_json()},

--- a/academy/manager.py
+++ b/academy/manager.py
@@ -492,7 +492,7 @@ class Manager(Generic[ExchangeTransportT], NoPickleMixin):
             blocking: Wait for the agent to exit before returning.
             raise_error: Raise the error returned by the agent if
                 `blocking=True`.
-            terminate: Override the termination agent of the agent defined
+            terminate: Override the termination behavior of the agent defined
                 in the [`RuntimeConfig`][academy.runtime.RuntimeConfig].
             timeout: Optional timeout is seconds when `blocking=True`.
 

--- a/tests/unit/exchange/cloud/server_test.py
+++ b/tests/unit/exchange/cloud/server_test.py
@@ -31,6 +31,7 @@ from academy.exchange.cloud.server import create_app
 from academy.exchange.cloud.server import StatusCode
 from academy.identifier import AgentId
 from academy.identifier import UserId
+from academy.message import Message
 from academy.message import PingRequest
 from academy.socket import open_port
 from testing.constant import TEST_SLEEP_INTERVAL
@@ -146,7 +147,7 @@ async def test_mailbox_manager_send_recv() -> None:
     uid = UserId.new()
     manager.create_mailbox(user_id, uid)
 
-    message = PingRequest(src=uid, dest=uid)
+    message = Message.create(src=uid, dest=uid, body=PingRequest())
     with pytest.raises(ForbiddenError):
         await manager.put(bad_user, message)
     await manager.put(user_id, message)
@@ -162,7 +163,7 @@ async def test_mailbox_manager_send_recv() -> None:
 async def test_mailbox_manager_bad_identifier() -> None:
     manager = _MailboxManager()
     uid = UserId.new()
-    message = PingRequest(src=uid, dest=uid)
+    message = Message.create(src=uid, dest=uid, body=PingRequest())
 
     with pytest.raises(BadEntityIdError):
         await manager.get(None, uid)
@@ -177,7 +178,7 @@ async def test_mailbox_manager_mailbox_closed() -> None:
     uid = UserId.new()
     manager.create_mailbox(None, uid)
     await manager.terminate(None, uid)
-    message = PingRequest(src=uid, dest=uid)
+    message = Message.create(src=uid, dest=uid, body=PingRequest())
 
     with pytest.raises(MailboxTerminatedError):
         await manager.get(None, uid)
@@ -402,7 +403,7 @@ async def test_globus_auth_client_create_discover_close(auth_client) -> None:
 async def test_globus_auth_client_message(auth_client) -> None:
     aid: AgentId[Any] = AgentId.new(name='test')
     cid = UserId.new()
-    message = PingRequest(src=cid, dest=aid)
+    message = Message.create(src=cid, dest=aid, body=PingRequest())
 
     # Create agent
     response = await auth_client.post(

--- a/tests/unit/exchange/hybrid_test.py
+++ b/tests/unit/exchange/hybrid_test.py
@@ -12,6 +12,7 @@ from academy.exchange.hybrid import HybridExchangeFactory
 from academy.exchange.hybrid import HybridExchangeTransport
 from academy.exchange.hybrid import uuid_to_base32
 from academy.identifier import UserId
+from academy.message import Message
 from academy.message import PingRequest
 from academy.socket import open_port
 from testing.agents import EmptyAgent
@@ -51,9 +52,10 @@ async def test_send_to_mailbox_direct(
     factory = hybrid_exchange_factory
     async with await factory._create_transport() as transport1:
         async with await factory._create_transport() as transport2:
-            message = PingRequest(
+            message = Message.create(
                 src=transport1.mailbox_id,
                 dest=transport2.mailbox_id,
+                body=PingRequest(),
             )
             for _ in range(3):
                 await transport1.send(message)
@@ -71,7 +73,11 @@ async def test_send_to_mailbox_indirect(
     messages = 3
     async with await factory._create_transport() as transport1:
         aid = (await transport1.register_agent(EmptyAgent)).agent_id
-        message = PingRequest(src=transport1.mailbox_id, dest=aid)
+        message = Message.create(
+            src=transport1.mailbox_id,
+            dest=aid,
+            body=PingRequest(),
+        )
         for _ in range(messages):
             await transport1.send(message)
 
@@ -118,9 +124,10 @@ async def test_send_to_mailbox_bad_cached_address(
         async with await factory1._create_transport(
             mailbox_id=aid,
         ) as transport2:
-            message = PingRequest(
+            message = Message.create(
                 src=transport1.mailbox_id,
                 dest=transport2.mailbox_id,
+                body=PingRequest(),
             )
             await transport1.send(message)
             received = await transport2.recv(timeout=TEST_CONNECTION_TIMEOUT)

--- a/tests/unit/handle_test.py
+++ b/tests/unit/handle_test.py
@@ -16,6 +16,7 @@ from academy.handle import ProxyHandle
 from academy.handle import RemoteHandle
 from academy.handle import UnboundRemoteHandle
 from academy.manager import Manager
+from academy.message import Message
 from academy.message import PingRequest
 from testing.agents import CounterAgent
 from testing.agents import EmptyAgent
@@ -219,7 +220,11 @@ async def test_client_remote_handle_log_bad_response(
     #     error produced by user) with no corresponding handle to
     #     send the response to.
     await handle.exchange.send(
-        PingRequest(src=handle.agent_id, dest=handle.client_id),
+        Message.create(
+            src=handle.agent_id,
+            dest=handle.client_id,
+            body=PingRequest(),
+        ),
     )
     assert await handle.ping() > 0
     await handle.shutdown()


### PR DESCRIPTION
# Description
<!--- Describe your changes in detail --->

This is a follow-up to #156 and #157 which patched some message types to lazily deserialize user types that might not be available server side.

This refactors messages to use header/body model so that headers can be read without needing to deserialize the body. As a result, `Message` is no longer a union type but an actual type that is generic on the underlying body type (i.e., action request, error response, etc.). This required touching quite a few files to update annotation signatures.

In addition, there is no longer a 1:1 relationship between a request type and its response type. Now there is an `ActionResponse`, `ErrorResponse`, and `SuccessResponse`. This has a few benefits:
* Response types are either successes or failures. No need to check if the `exception` is set to know if `result` is valid on `ActionResponse`
* We can return an error response to a request server-side (e.g., in the HTTP server) without needing to deserialize the body to figure out which kind of request it was
* Simplified the response handling logic in the `Handle` which previously needed to handle the success and failure case for each response type.

This shouldn't be a breaking change as the message implementations are all internal.

### Fixes
<!--- List any issue numbers above that this PR addresses --->

- Fixes #155

### Type of Change
<!--- Check which off the following types describe this PR --->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Refactoring (internal implementation changes)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update (no changes to the code)
- [ ] CI change (changes to CI workflows, packages, templates, etc.)
- [ ] Version changes (changes to the package or dependency versions)

## Testing
<!--- Please describe the test ran to verify changes --->

All unit tests pass after updating the message creation syntax.

## Pull Request Checklist

Please confirm the PR meets the following requirements.
- [x] Relevant tags are added (breaking, bug, dependencies, documentation, enhancement, refactor).
- [x] Code changes pass `pre-commit` (e.g., ruff, mypy, etc.).
- [x] Tests have been added to show the fix is effective or that the new feature works.
- [x] New and existing unit tests pass locally with the changes.
- [x] Docs have been updated and reviewed if relevant.
