### PR TITLE
Update contributing guide and templates

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,23 +1,24 @@
-# Description
-<!--- Describe your changes in detail --->
+## Summary
+<!--- Provide a summary of the changes --->
 
 
-### Fixes
+## Related Issue
 <!--- List any issue numbers above that this PR addresses --->
 
-- Fixes #XX
-- Fixes #XX
+- Closes #XX
+- Related to #XX _(if applicable)_
 
-### Type of Change
-<!--- Check which off the following types describe this PR --->
+### Changes
+<!--- Check which of the following changes were made --->
 
+- [ ] Breaking (backwards incompatible changes to public interfaces)
 - [ ] Bug fix (non-breaking change which fixes an issue)
-- [ ] New feature (non-breaking change which adds functionality)
-- [ ] Refactoring (internal implementation changes)
-- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
-- [ ] Documentation update (no changes to the code)
-- [ ] CI change (changes to CI workflows, packages, templates, etc.)
-- [ ] Version changes (changes to the package or dependency versions)
+- [ ] Enhancement (non-breaking change or feature addition)
+- [ ] Refactor (internal code or design clean up)
+- [ ] Documentation (no changes to the code)
+- [ ] Test (changes or additions to testing)
+- [ ] Build (change to CI workflows or build processes)
+- [ ] Package (changes to package metadata or dependency versions)
 
 ## Testing
 <!--- Please describe the test ran to verify changes --->
@@ -27,7 +28,7 @@ N/A
 ## Pull Request Checklist
 
 Please confirm the PR meets the following requirements.
-- [ ] Relevant tags are added (breaking, bug, dependencies, documentation, enhancement, refactor).
+- [ ] Relevant tags are added based on the types of changes.
 - [ ] Code changes pass `pre-commit` (e.g., ruff, mypy, etc.).
 - [ ] Tests have been added to show the fix is effective or that the new feature works.
 - [ ] New and existing unit tests pass locally with the changes.

--- a/.github/release.yml
+++ b/.github/release.yml
@@ -5,41 +5,34 @@ changelog:
     authors:
       - pre-commit-ci
   categories:
-    # Provide steps for upgrading the package and adjusting for
-    # breaking changes. No PRs included here.
-    - title: Upgrade Steps
-      exclude:
-        labels:
-          - "*"
-    # All PRs tagged as "breaking"
     - title: Breaking Changes
       labels:
         - breaking
-    # All PRs tagged as "enhancement"
     - title: New Features
       labels:
         - enhancement
-    # All PRs tagged as "bug"
     - title: Bug Fixes
       labels:
         - bug
-    # All PRs not tagged as the above or below
-    - title: Improvements
+    - title: Security
+      labels:
+        - security
+    - title: Internal Changes
       labels:
         - refactor
+        - test
       exclude:
         labels:
-          - dependencies
+          - build
+          - package
           - documentation
-    # All PRs tagged as documentation
-    - title: Improvements
+    - title: Documentation
       labels:
         - documentation
-    # All PRs tagged "dependencies"
-    - title: Dependencies
+    - title: Build and Packaging
       labels:
-        - dependencies
-    # All PRs not tagged as the above
-    - title: Other Changes
+        - build
+        - package
+    - title: Uncategorized Changes
       labels:
         - "*"

--- a/docs/contributing/issues-pull-requests.md
+++ b/docs/contributing/issues-pull-requests.md
@@ -10,23 +10,15 @@ If you open an issue for a specific problem, please follow the template guides.
 We use the standard GitHub contribution cycle where all contributions are made via pull requests (including code owners!).
 
 1. Fork the repository and clone to your local machine.
-2. Create local changes.
-    - Changes should conform to the style and testing guidelines, referenced above.
-    - Preferred commit message format ([source](https://cbea.ms/git-commit/){target=_blank}):
-        * separate subject from body with a blank line,
-        * limit subject line to 50 characters,
-        * capitalize first word of subject line,
-        * do not end the subject line with a period,
-        * use the imperative mood for subject lines,
-        * include related issue numbers at end of subject line,
-        * wrap body at 72 characters, and
-        * use the body to explain what/why rather than how.
-        * *Example*: `Fix concurrency bug in Store (#42)`
-
-3. Push commits to your fork.
-    - Please squash commits fixing mistakes to keep the git history clean.
-      For example, if commit "b" follows commit "a" and only fixes a small typo from "a", please squash "a" and "b" into a single, correct commit.
-      This keeps the commit history readable and easier to search through when debugging (e.g., git blame/bisect).
-4. Open a pull request in this repository.
-    - The pull request should include a description of the motivation for the PR and included changes.
-      A PR template is provided to guide this process.
+1. Create a branch for your changes using a descriptive name for the change, such as the issue being addressed.
+   ```
+   git checkout -b {user}-issue-{xx}
+   ```
+1. Create your changes.
+    - Please open an issue to discuss larger changes; bug fixes and minor changes do not require an issue.
+    - Changes should conform to the style and testing guidelines.
+    - Keep commits focused and use clear messages.
+    - Avoid committing unrelated changes in the same PR.
+1. Test your changes as discussed in the contributing guide.
+1. Commit your changes and push your branch.
+1. Open a pull request in this repository, fill out the PR template, and link any relevant issues.

--- a/docs/contributing/releases.md
+++ b/docs/contributing/releases.md
@@ -1,13 +1,10 @@
 ## Release Timeline
 
 Releases are created on an as-needed basis.
-Milestones in the [Issue Tracker](https://github.com/proxystore/academy/issues){target=_blank} are used to track features to be included in upcoming releases.
 
 ## Versioning
 
 Academy uses [semver](https://semver.org/) as its versioning system.
-Rather, changes are only considered breaking if they change the way an application is run.
-For example, the command from a prior release no longer works in the following release.
 While Academy is in major version zero (0.y.z), breaking changes will be released in minor version updates.
 
 ## Creating Releases
@@ -19,8 +16,7 @@ While Academy is in major version zero (0.y.z), breaking changes will be release
    start at 0 and pre-release/post-release/dev-release segments start at 1.
 2. Update the version in `pyproject.toml` to `{VERSION}`.
 3. Commit and merge the version updates/changelogs into main.
-4. Tag the release commit and push (typically this is the commit updating the
-   version numbers).
+4. Pull the latest changes to main, tag the commit updating the version, and push the tag.
    ```bash
    $ git tag -s v{VERSION} -m "Academy v{VERSION}"
    $ git push origin v{VERSION}

--- a/docs/contributing/style-guide.md
+++ b/docs/contributing/style-guide.md
@@ -2,6 +2,9 @@ The Python code and docstring format mostly follows Google's [Python Style Guide
 
 **Nits:**
 
+* Avoid redundant comments---write _why_ and not _what_.
+* Keep comments and docstrings up-to-date when changing functions and classes.
+* Don't include unrelated formatting or refactors in a feature PR.
 * Avoid imports in `__init__.py` (reduces the likelihood of circular imports).
 * Prefer pure functions where possible.
 * Define all class attributes inside `__init__` so all attributes are visible in one place.
@@ -9,7 +12,7 @@ The Python code and docstring format mostly follows Google's [Python Style Guide
 * Prefer f-strings (`#!python f'name: {name}`) over string format (`#!python 'name: {}'.format(name)`).
   Never use the `%` operator.
 * Prefer [typing.NamedTuple][] over [collections.namedtuple][].
-* Use lower-case and no punctuation for log messages, but use upper-case and punctuation for exception values.
+* Use sentence case for error and log messages, but only include punctuation for errors.
   ```python
   logger.info(f'new connection opened to {address}')
   raise ValueError('Name must contain alphanumeric characters only.')


### PR DESCRIPTION
# Description
<!--- Describe your changes in detail --->

During the last release I noticed the PR and release template were out-of-date with the GitHub tags we were using on PRs.

Also updating the contributing guide along with the updates to the PR template.

### Fixes N/A
<!--- List any issue numbers above that this PR addresses --->

### Type of Change
<!--- Check which off the following types describe this PR --->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Refactoring (internal implementation changes)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Documentation update (no changes to the code)
- [x] CI change (changes to CI workflows, packages, templates, etc.)
- [ ] Version changes (changes to the package or dependency versions)

## Testing
<!--- Please describe the test ran to verify changes --->

N/A

## Pull Request Checklist

Please confirm the PR meets the following requirements.
- [x] Relevant tags are added (breaking, bug, dependencies, documentation, enhancement, refactor).
- [x] Code changes pass `pre-commit` (e.g., ruff, mypy, etc.).
- [x] Tests have been added to show the fix is effective or that the new feature works.
- [x] New and existing unit tests pass locally with the changes.
- [x] Docs have been updated and reviewed if relevant.
