### PR TITLE
Add GitHub Issue templates

### DIFF
--- a/.github/ISSUE_TEMPLATE/01_bug.yml
+++ b/.github/ISSUE_TEMPLATE/01_bug.yml
@@ -1,0 +1,53 @@
+name: Bug report
+description: Report errors or unexpected results.
+labels: ["bug"]
+body:
+  - type: textarea
+    id: freeform
+    attributes:
+      label: Describe the problem.
+      description: >
+        Please describe the issue encountered, what you expected to happen,
+        and steps to reproduce the issue.
+    validations:
+      required: true
+
+  - type: textarea
+    id: install
+    attributes:
+      label: How did you install and run the code?
+      description: >
+        E.g., install via pip, install from source, etc. **Note:** this will
+        be rendered as console text automatically.
+      placeholder: |
+        $ pip install ...
+        $ python my_script.py
+      render: console
+    validations:
+      required: false
+
+  - type: input
+    id: package-version
+    attributes:
+      label: Version
+      description: >
+        Academy version used or commit ID if installed from source.
+      placeholder: "v0.3.1"
+    validations:
+      required: true
+
+  - type: input
+    id: python-version
+    attributes:
+      label: Python Version
+      placeholder: "3.10"
+    validations:
+      required: true
+
+  - type: input
+    id: platform
+    attributes:
+      label: OS and Platform
+      placeholder: "x86 Linux, ARM MacOS, etc."
+    validations:
+      required: true

--- a/.github/ISSUE_TEMPLATE/02_feature.yml
+++ b/.github/ISSUE_TEMPLATE/02_feature.yml
@@ -1,0 +1,24 @@
+name: Feature request
+description: Request a new feature or enhancement.
+labels: ["enhancement"]
+body:
+  - type: textarea
+    id: request
+    attributes:
+      label: Describe the Request
+      description: >
+        Please describe the new functionality, why it is needed, and how it would be used. Include any relevant context.
+    validations:
+      required: true
+
+  - type: textarea
+    id: example
+    attributes:
+      label: Sample Code
+      description: >
+        If relevant, please provide sample code such as the proposed
+        interface, usage, or results. **Note:** this will be rendered as
+        Python code automatically.
+      render: python
+    validations:
+      required: false

--- a/.github/ISSUE_TEMPLATE/03_docs.yml
+++ b/.github/ISSUE_TEMPLATE/03_docs.yml
@@ -1,0 +1,13 @@
+name: Documentation improvement
+description: Suggest improvements to the documentation.
+labels: ["documentation"]
+body:
+  - type: textarea
+    id: freeform
+    attributes:
+      label: Describe the Request
+      description: >
+        Please describe limitations of the current documentation or
+        suggested improvements.
+    validations:
+      required: true

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,1 @@
+blank_issues_enabled: true

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -8,7 +8,7 @@
 - Closes #XX
 - Related to #XX _(if applicable)_
 
-### Changes
+## Changes
 <!--- Check which of the following changes were made --->
 
 - [ ] Breaking (backwards incompatible changes to public interfaces)


### PR DESCRIPTION
## Summary
<!--- Provide a summary of the changes --->

The current issue templates are inherited from the ProxyStore org's default which always assign issues to me. These new templates are slightly updated and don't assign me by default anymore :).

## Related Issue
<!--- List any issue numbers above that this PR addresses --->

N/A

### Changes
<!--- Check which of the following changes were made --->

- [ ] Breaking (backwards incompatible changes to public interfaces)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] Enhancement (non-breaking change or feature addition)
- [ ] Refactor (internal code or design clean up)
- [ ] Documentation (no changes to the code)
- [ ] Test (changes or additions to testing)
- [x] Build (change to CI workflows or build processes)
- [ ] Package (changes to package metadata or dependency versions)

## Testing
<!--- Please describe the test ran to verify changes --->

N/A

## Pull Request Checklist

Please confirm the PR meets the following requirements.
- [x] Relevant tags are added based on the types of changes.
- [x] Code changes pass `pre-commit` (e.g., ruff, mypy, etc.).
- [x] Tests have been added to show the fix is effective or that the new feature works.
- [x] New and existing unit tests pass locally with the changes.
- [x] Docs have been updated and reviewed if relevant.
