### PR TITLE
Hold action and loop execution until agent startup sequence has completed

### DIFF
--- a/academy/agent.py
+++ b/academy/agent.py
@@ -251,6 +251,11 @@ class Agent:
     async def agent_on_startup(self) -> None:
         """Callback invoked at the end of an agent's startup sequence.
 
+        Control loops will not start and action requests will not be
+        processed until after this callback completes. Thus, it is safe to
+        initialize resources in this callback that are needed by actions or
+        loops.
+
         See
         [`Runtime.run_until_complete()`][academy.runtime.Runtime.run_until_complete]
         for more details on the startup sequence.

--- a/docs/faq.md
+++ b/docs/faq.md
@@ -43,3 +43,9 @@ The `__init__` method of an [`Agent`][academy.agent.Agent] is called in one of t
 In both scenarios, it is unsafe to perform communication operations (i.e., invoking an action on a remote agent) in `__init__` because connection resources and background tasks have not yet been initialized.
 
 The [`Agent.agent_on_startup()`][academy.agent.Agent.agent_on_startup] callback can be used instead to perform communication once the agent is in a running state.
+
+!!! warning
+
+    Be careful when invoking actions on remote agents from the on startup callback.
+    An agent will not process incoming action requests until after [`Agent.agent_on_startup()`][academy.agent.Agent.agent_on_startup] has completed.
+    This can cause deadlocks when Agent A's startup callback makes a request to Agent B and then Agent B makes a request back to Agent A.


### PR DESCRIPTION
## Summary
<!--- Provide a summary of the changes --->

Hold action and loop execution until agent startup sequence has completed. This avoids an action or loop executing before any resources have been setup in `agent_on_setup()`.

## Related Issue
<!--- List any issue numbers above that this PR addresses --->

- Closes #170

## Changes
<!--- Check which of the following changes were made --->

- [ ] Breaking (backwards incompatible changes to public interfaces)
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] Enhancement (non-breaking change or feature addition)
- [ ] Refactor (internal code or design clean up)
- [ ] Documentation (no changes to the code)
- [ ] Test (changes or additions to testing)
- [ ] Build (change to CI workflows or build processes)
- [ ] Package (changes to package metadata or dependency versions)

## Testing
<!--- Please describe the test ran to verify changes --->

Added a test that reproduced the initial error and is fixed by this change.

## Pull Request Checklist

Please confirm the PR meets the following requirements.
- [x] Relevant tags are added based on the types of changes.
- [x] Code changes pass `pre-commit` (e.g., ruff, mypy, etc.).
- [x] Tests have been added to show the fix is effective or that the new feature works.
- [x] New and existing unit tests pass locally with the changes.
- [x] Docs have been updated and reviewed if relevant.
