### PR TITLE
Add helper method for safely running sync functions within async actions

### DIFF
--- a/academy/agent.py
+++ b/academy/agent.py
@@ -572,7 +572,7 @@ def event(
             if not isinstance(event, asyncio.Event):
                 raise TypeError(
                     f'Attribute {name} of {type(self).__class__} has type '
-                    f'{type(event).__class__}. Expected threading.Event.',
+                    f'{type(event).__class__}. Expected asyncio.Event.',
                 )
 
             logger.debug(

--- a/academy/context.py
+++ b/academy/context.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 import asyncio
 import dataclasses
+from concurrent.futures import ThreadPoolExecutor
 from typing import Any
 from typing import Generic
 from typing import TYPE_CHECKING
@@ -73,5 +74,7 @@ class AgentContext(Generic[AgentT]):
     """ID of the exchange as registered with the exchange."""
     exchange_client: AgentExchangeClient[AgentT, Any]
     """Client used by agent to communicate with the exchange."""
+    executor: ThreadPoolExecutor
+    """Thread-pool executor used for running synchronous tasks."""
     shutdown_event: asyncio.Event
     """Shutdown event used to signal the agent to shutdown."""

--- a/academy/event.py
+++ b/academy/event.py
@@ -2,67 +2,6 @@ from __future__ import annotations
 
 import asyncio
 import contextlib
-import threading
-from typing import Any
-from typing import Callable
-
-
-def _or_set(event: Any) -> None:
-    event._set()
-    event.changed()
-
-
-def _or_clear(event: Any) -> None:
-    event._clear()
-    event.changed()
-
-
-def _orify(
-    event: threading.Event,
-    changed_callback: Callable[[], None],
-) -> None:
-    event._set = event.set  # type: ignore[attr-defined]
-    event._clear = event.clear  # type: ignore[attr-defined]
-    event.changed = changed_callback  # type: ignore[attr-defined]
-    event.set = lambda: _or_set(event)  # type: ignore[method-assign]
-    event.clear = lambda: _or_clear(event)  # type: ignore[method-assign]
-
-
-def or_event(*events: threading.Event) -> threading.Event:
-    """Create a combined event that is set when any input events are set.
-
-    Note:
-        The creator can wait on the combined event, but must still check
-        each individual event to see which was set.
-
-    Warning:
-        This works by dynamically replacing methods on the inputs events
-        with custom methods that trigger callbacks.
-
-    Note:
-        Based on this Stack Overflow
-        [answer](https://stackoverflow.com/a/12320352).
-
-    Args:
-        events: One or more events to combine.
-
-    Returns:
-        A single event that is set when any of the input events is set.
-    """
-    combined = threading.Event()
-
-    def changed() -> None:
-        bools = [e.is_set() for e in events]
-        if any(bools):
-            combined.set()
-        else:
-            combined.clear()
-
-    for e in events:
-        _orify(e, changed)
-
-    changed()
-    return combined
 
 
 async def wait_event_async(

--- a/docs/faq.md
+++ b/docs/faq.md
@@ -33,6 +33,19 @@ async with await Manager(..., executors=executor) as manager:
 
 This section highlights common best practices for developing applications in Academy.
 
+### Avoid blocking calls in async agent methods
+
+When writing methods on an [`Agent`][academy.agent.Agent] that use `async def`, such as [`@action`][academy.agent.action] and [`@loop`][academy.agent.loop] methods, avoid calling long-running or blocking synchronous functions directly.
+Doing so will block the entire asyncio event loop, degrading the responsiveness and concurrency of your agent.
+
+To safely run synchronous (blocking) code inside async methods, use [`Agent.agent_run_sync()`][academy.agent.Agent.agent_run_sync] which runs the function in a separate thread, keeping the event loop free to do other work.
+```python
+@action
+async def do_work(self) -> None:
+    result = await self.agent_run_sync(expensive_sync_func)
+    ...
+```
+
 ### Avoid communication operations during agent initialization
 
 The `__init__` method of an [`Agent`][academy.agent.Agent] is called in one of two places:

--- a/tests/unit/event_test.py
+++ b/tests/unit/event_test.py
@@ -1,36 +1,11 @@
 from __future__ import annotations
 
 import asyncio
-import threading
 
 import pytest
 
-from academy.event import or_event
 from academy.event import wait_event_async
 from testing.constant import TEST_SLEEP_INTERVAL
-
-
-def test_or_event() -> None:
-    a = threading.Event()
-    b = threading.Event()
-
-    c = or_event(a, b)
-
-    assert not c.is_set()
-    a.set()
-    assert c.is_set()
-    a.clear()
-    assert not c.is_set()
-
-    a.set()
-    b.set()
-    assert c.is_set()
-
-    # Both events must be cleared
-    a.clear()
-    assert c.is_set()
-    b.clear()
-    assert not c.is_set()
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## Summary
<!--- Provide a summary of the changes --->

Adds the `Agent.agent_run_sync()` helper method for safely running sync functions within async actions/loops/methods. This is essentially a wrapper around `loop.run_in_executor` with some extra features for supporting keyword arguments, configuring the max concurrency, and logging warnings when the thread pool executor is full.

Plenty of applications will want to call synchronous functions in their agents, such as third-party libraries, so I think it will be good to have a suggested mechanism for doing so.

If users want to customize the sync method calling, they can still use `loop.run_in_executor` manually. I considered adding an `executor` parameter to `Agent.agent_run_sync()` so agents could create their own executor (i.e., a process pool executor), but this breaks the paramspec typing for mypy and means we can't reliably raise warnings when the executor is overloaded.

We had previously discussed support both sync and async actions/loops. My idea for this was to have the runtime to schedule sync actions/loops in a thread pool using a mechanism similar to this, but I think the complexity of supporting multiple code paths is not worth it (i.e., sync/async variants of decorators and startup/shutdown in the runtime).

**Note:** I also removed some dead code related to threading from the v0.1/sync days.

## Related Issue
<!--- List any issue numbers above that this PR addresses --->

Closes #99

As actions are now async, there's no upper bound on the concurrent actions to be executed so the type of deadlock encountered in this issue is not possible. I had left the issue open in case we revisited sync actions, but as discussed above I think this approach of running sync code in a thread from an async action is better. I did, however, use the suggestion of logging warnings when the thread pool is overloaded.

## Changes
<!--- Check which of the following changes were made --->

- [ ] Breaking (backwards incompatible changes to public interfaces)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] Enhancement (non-breaking change or feature addition)
- [ ] Refactor (internal code or design clean up)
- [ ] Documentation (no changes to the code)
- [ ] Test (changes or additions to testing)
- [ ] Build (change to CI workflows or build processes)
- [ ] Package (changes to package metadata or dependency versions)

## Testing
<!--- Please describe the test ran to verify changes --->

Added new unit tests.

## Pull Request Checklist

Please confirm the PR meets the following requirements.
- [x] Relevant tags are added based on the types of changes.
- [x] Code changes pass `pre-commit` (e.g., ruff, mypy, etc.).
- [x] Tests have been added to show the fix is effective or that the new feature works.
- [x] New and existing unit tests pass locally with the changes.
- [x] Docs have been updated and reviewed if relevant.
