### PR TITLE
Read exchange client from context in handle

### DIFF
--- a/academy/agent.py
+++ b/academy/agent.py
@@ -37,7 +37,6 @@ from academy.handle import HandleDict
 from academy.handle import HandleList
 from academy.handle import ProxyHandle
 from academy.handle import RemoteHandle
-from academy.handle import UnboundRemoteHandle
 
 if TYPE_CHECKING:
     from academy.context import AgentContext
@@ -202,7 +201,6 @@ class Agent:
         """
         handle_types = (
             ProxyHandle,
-            UnboundRemoteHandle,
             RemoteHandle,
             HandleDict,
             HandleList,

--- a/academy/agent.py
+++ b/academy/agent.py
@@ -33,10 +33,6 @@ else:  # pragma: <3.11 cover
 from academy.event import wait_event_async
 from academy.exception import AgentNotInitializedError
 from academy.handle import Handle
-from academy.handle import HandleDict
-from academy.handle import HandleList
-from academy.handle import ProxyHandle
-from academy.handle import RemoteHandle
 
 if TYPE_CHECKING:
     from academy.context import AgentContext
@@ -186,33 +182,6 @@ class Agent:
             if _is_agent_method_type(attr, 'loop'):
                 loops[name] = attr
         return loops
-
-    def _agent_handles(
-        self,
-    ) -> dict[
-        str,
-        Handle[Any] | HandleDict[Any, Any] | HandleList[Any],
-    ]:
-        """Get instance attributes that are agent handles.
-
-        Returns:
-            Dictionary mapping attribute names to agent handles or \
-            data structures of handles.
-        """
-        handle_types = (
-            ProxyHandle,
-            RemoteHandle,
-            HandleDict,
-            HandleList,
-        )
-        handles: dict[
-            str,
-            Handle[Any] | HandleDict[Any, Any] | HandleList[Any],
-        ] = {}
-        for name, attr in self._agent_attributes():
-            if isinstance(attr, handle_types):
-                handles[name] = attr
-        return handles
 
     @classmethod
     def _agent_mro(cls) -> tuple[str, ...]:

--- a/academy/context.py
+++ b/academy/context.py
@@ -10,6 +10,7 @@ from typing import TypeVar
 
 from academy.exchange import AgentExchangeClient
 from academy.handle import Handle
+from academy.handle import RemoteHandle
 from academy.identifier import AgentId
 from academy.identifier import EntityId
 from academy.identifier import UserId
@@ -52,8 +53,9 @@ class ActionContext:
                 'Cannot create handle to source because it is a user entity.',
             )
         if self._source_handle is None:
-            self._source_handle = self._exchange_client.get_handle(
+            self._source_handle = RemoteHandle(
                 self.source_id,
+                self._exchange_client,
             )
         return self._source_handle
 

--- a/academy/exception.py
+++ b/academy/exception.py
@@ -121,13 +121,9 @@ class HandleClosedError(Exception):
 class HandleNotBoundError(Exception):
     """Handle to agent is in an unbound state.
 
-    An [`UnboundRemoteHandle`][academy.handle.UnboundRemoteHandle] is
+    A [`RemoteHandle`][academy.handle.RemoteHandle] is
     initialized with a target agent ID, but is not attached to an exchange
     client that the handle can use for communication.
-
-    An unbound handle can be turned into a usable handle by binding it to
-    an exchange client with
-    [`UnboundRemoteHandle.bind_to_client()`][academy.handle.UnboundRemoteHandle.bind_to_client].
     """
 
     def __init__(self, aid: AgentId[Any]) -> None:

--- a/academy/exception.py
+++ b/academy/exception.py
@@ -118,17 +118,36 @@ class HandleClosedError(Exception):
         super().__init__(message)
 
 
-class HandleNotBoundError(Exception):
-    """Handle to agent is in an unbound state.
+class ExchangeClientNotFoundError(Exception):
+    """Handle to agent can not find an exchange client to use.
 
     A [`RemoteHandle`][academy.handle.RemoteHandle] is
-    initialized with a target agent ID, but is not attached to an exchange
-    client that the handle can use for communication.
+    initialized with a target agent ID, but was not initialized with an
+    exchange client, and is not used in a context where an exchange
+    client could be inferred. Typically this can be resolved by using a
+    [`ExchangeClient`][academy.exchange.ExchangeClient] or
+    [`Manager`][academy.manager.Manager] as a context manager.
     """
 
     def __init__(self, aid: AgentId[Any]) -> None:
         super().__init__(
-            f'Handle to {aid} is not bound to an exchange client. See the '
+            f'Handle to {aid} can not find an exchange client to use. See the '
+            'exception docstring for troubleshooting.',
+        )
+
+
+class HandleReuseError(Exception):
+    """Handle to agent used by multiple clients/agents.
+
+    A [`RemoteHandle`][academy.handle.RemoteHandle] is used by multiple
+    clients or agents. This means the handle would try to send and
+    receive at multiple mailbox addresses. This can be resolved by
+    calling handle.clone() (usually at agent initialization).
+    """
+
+    def __init__(self, aid: AgentId[Any]) -> None:
+        super().__init__(
+            f'Handle to {aid} used by multiple clients/agents. See the '
             'exception docstring for troubleshooting.',
         )
 

--- a/academy/exchange/__init__.py
+++ b/academy/exchange/__init__.py
@@ -231,33 +231,6 @@ class ExchangeClient(abc.ABC, Generic[ExchangeTransportT]):
         """Get an exchange factory."""
         return self._transport.factory()
 
-    def get_handle(self, aid: AgentId[AgentT]) -> RemoteHandle[AgentT]:
-        """Create a new handle to an agent.
-
-        A handle acts like a reference to a remote agent, enabling a user
-        to manage the agent or asynchronously invoke actions.
-
-        Args:
-            aid: Agent to create an handle to. The agent must be registered
-                with the same exchange.
-
-        Returns:
-            Handle to the agent.
-
-        Raises:
-            TypeError: if `aid` is not an instance of
-                [`AgentId`][academy.identifier.AgentId].
-        """
-        if not isinstance(aid, AgentId):
-            raise TypeError(
-                f'Handle must be created from an {AgentId.__name__} '
-                f'but got identifier with type {type(aid).__name__}.',
-            )
-        handle = RemoteHandle(aid, self)
-        self._handles[handle.handle_id] = handle
-        logger.info('Created handle to %s', aid)
-        return handle
-
     def register_handle(self, handle: RemoteHandle[AgentT]) -> None:
         """Register an existing handle to receive messages.
 

--- a/academy/handle.py
+++ b/academy/handle.py
@@ -8,6 +8,7 @@ import time
 import uuid
 from collections.abc import Iterable
 from collections.abc import Mapping
+from contextvars import ContextVar
 from types import TracebackType
 from typing import Any
 from typing import Generic
@@ -321,72 +322,10 @@ class ProxyHandle(Generic[AgentT]):
         self._agent_closed = True if terminate is None else terminate
 
 
-class UnboundRemoteHandle(Generic[AgentT]):
-    """Handle to a remote agent that not bound to a mailbox.
-
-    Warning:
-        An unbound handle must be bound before use. Otherwise all methods
-        will raise an `HandleNotBoundError` when attempting to send a message
-        to the remote agent.
-
-    Args:
-        agent_id: EntityId of the agent.
-    """
-
-    def __init__(self, agent_id: AgentId[AgentT]) -> None:
-        self.agent_id = agent_id
-
-    def __repr__(self) -> str:
-        name = type(self).__name__
-        return f'{name}(agent_id={self.agent_id!r})'
-
-    def __str__(self) -> str:
-        return f'{type(self).__name__}<agent: {self.agent_id}>'
-
-    def __getattr__(self, name: str) -> Any:
-        raise AttributeError(
-            'Actions cannot be invoked via an unbound handle.',
-        )
-
-    @property
-    def client_id(self) -> EntityId:
-        """Raises [`RuntimeError`][RuntimeError] when unbound."""
-        raise RuntimeError('An unbound handle has no client ID.')
-
-    def bind_to_client(
-        self,
-        client: ExchangeClient[Any],
-    ) -> RemoteHandle[AgentT]:
-        """Bind the handle to an existing mailbox.
-
-        Args:
-            client: Exchange client.
-
-        Returns:
-            Remote handle bound to the exchange client.
-        """
-        return client.get_handle(self.agent_id)
-
-    async def action(self, action: str, /, *args: Any, **kwargs: Any) -> R:
-        """Raises [`HandleNotBoundError`][academy.exception.HandleNotBoundError]."""  # noqa: E501
-        raise HandleNotBoundError(self.agent_id)
-
-    async def close(
-        self,
-        wait_futures: bool = True,
-        *,
-        timeout: float | None = None,
-    ) -> None:
-        """Raises [`HandleNotBoundError`][academy.exception.HandleNotBoundError]."""  # noqa: E501
-        raise HandleNotBoundError(self.agent_id)
-
-    async def ping(self, *, timeout: float | None = None) -> float:
-        """Raises [`HandleNotBoundError`][academy.exception.HandleNotBoundError]."""  # noqa: E501
-        raise HandleNotBoundError(self.agent_id)
-
-    async def shutdown(self, *, terminate: bool | None = None) -> None:
-        """Raises [`HandleNotBoundError`][academy.exception.HandleNotBoundError]."""  # noqa: E501
-        raise HandleNotBoundError(self.agent_id)
+exchange_context: ContextVar[ExchangeClient[Any] | None] = ContextVar(
+    'exchange_client',
+    default=None,
+)
 
 
 class RemoteHandle(Generic[AgentT]):
@@ -399,14 +338,13 @@ class RemoteHandle(Generic[AgentT]):
 
     def __init__(
         self,
-        exchange: ExchangeClient[Any],
         agent_id: AgentId[AgentT],
+        exchange: ExchangeClient[Any] | None,
     ) -> None:
-        self.exchange = exchange
         self.agent_id = agent_id
-        self.client_id = exchange.client_id
+        self._exchange = exchange
 
-        if self.agent_id == self.client_id:
+        if self._exchange is not None and self.agent_id == self.client_id:
             raise ValueError(
                 'Cannot create handle to self. The IDs of the exchange '
                 f'client and the target agent are the same: {self.agent_id}.',
@@ -417,6 +355,34 @@ class RemoteHandle(Generic[AgentT]):
 
         self._futures: dict[uuid.UUID, asyncio.Future[Any]] = {}
         self._closed = False
+
+    @property
+    def exchange(self) -> ExchangeClient[Any]:
+        """Exchange client used to send messages.
+
+        Returns:
+            The ExchangeClient
+
+        Raises:
+            HandleNotBoundError: If the exchange client can't be found.
+
+        """
+        exchange = exchange_context.get()
+        if exchange is None and self._exchange is None:
+            raise HandleNotBoundError(self.agent_id)
+        elif exchange is None and self._exchange is not None:
+            return self._exchange
+
+        assert exchange is not None
+        if self._exchange != exchange:
+            self._exchange = exchange
+            self._exchange.register_handle(self)
+        return exchange
+
+    @property
+    def client_id(self) -> EntityId:
+        """ID of the client for this handle."""
+        return self.exchange.client_id
 
     async def __aenter__(self) -> Self:
         return self
@@ -432,20 +398,17 @@ class RemoteHandle(Generic[AgentT]):
     def __reduce__(
         self,
     ) -> tuple[
-        type[UnboundRemoteHandle[Any]],
-        tuple[AgentId[AgentT]],
+        type[RemoteHandle[Any]],
+        tuple[AgentId[AgentT], None],
     ]:
-        return (UnboundRemoteHandle, (self.agent_id,))
+        return (RemoteHandle, (self.agent_id, None))
 
     def __repr__(self) -> str:
-        return (
-            f'{type(self).__name__}(agent_id={self.agent_id!r}, '
-            f'client_id={self.client_id!r}, exchange={self.exchange!r})'
-        )
+        return f'{type(self).__name__}(agent_id={self.agent_id!r})'
 
     def __str__(self) -> str:
         name = type(self).__name__
-        return f'{name}<agent: {self.agent_id}; mailbox: {self.client_id}>'
+        return f'{name}<agent: {self.agent_id}>'
 
     def __getattr__(self, name: str) -> Any:
         async def remote_method_call(*args: Any, **kwargs: Any) -> R:
@@ -453,9 +416,9 @@ class RemoteHandle(Generic[AgentT]):
 
         return remote_method_call
 
-    def clone(self) -> UnboundRemoteHandle[AgentT]:
+    def clone(self) -> RemoteHandle[AgentT]:
         """Create an unbound copy of this handle."""
-        return UnboundRemoteHandle(self.agent_id)
+        return RemoteHandle(self.agent_id, None)
 
     async def _process_response(self, response: Message[Response]) -> None:
         future = self._futures.pop(response.tag, None)
@@ -539,6 +502,7 @@ class RemoteHandle(Generic[AgentT]):
         loop = asyncio.get_running_loop()
         future: asyncio.Future[R] = loop.create_future()
         self._futures[request.tag] = future
+
         await self.exchange.send(request)
         logger.debug(
             'Sent action request from %s to %s (action=%r)',

--- a/academy/handle.py
+++ b/academy/handle.py
@@ -406,13 +406,11 @@ class RemoteHandle(Generic[AgentT]):
     def __repr__(self) -> str:
         try:
             exchange = self.exchange
-            client_id = self.client_id
         except HandleNotBoundError:
             exchange = None
-            client_id = None
         return (
             f'{type(self).__name__}(agent_id={self.agent_id!r}, '
-            f'client_id={client_id!r}, exchange={exchange!r})'
+            f'exchange={exchange!r})'
         )
 
     def __str__(self) -> str:

--- a/academy/handle.py
+++ b/academy/handle.py
@@ -408,9 +408,9 @@ class RemoteHandle(Generic[AgentT]):
         self,
     ) -> tuple[
         type[RemoteHandle[Any]],
-        tuple[AgentId[AgentT], None],
+        tuple[AgentId[AgentT],],
     ]:
-        return (RemoteHandle, (self.agent_id, None))
+        return (RemoteHandle, (self.agent_id,))
 
     def __repr__(self) -> str:
         try:

--- a/academy/manager.py
+++ b/academy/manager.py
@@ -446,7 +446,7 @@ class Manager(Generic[ExchangeTransportT], NoPickleMixin):
         handle = self._handles.get(agent_id, None)
         if handle is not None and not handle.closed():
             return handle
-        handle = self.exchange_client.get_handle(agent_id)
+        handle = RemoteHandle(agent_id)
         self._handles[agent_id] = handle
         return handle
 

--- a/academy/manager.py
+++ b/academy/manager.py
@@ -166,8 +166,8 @@ class Manager(Generic[ExchangeTransportT], NoPickleMixin):
         exc_value: BaseException | None,
         exc_traceback: TracebackType | None,
     ) -> None:
-        exchange_context.reset(self.exchange_context_token)
         await self.close()
+        exchange_context.reset(self.exchange_context_token)
 
     def __repr__(self) -> str:
         executors_repr = ', '.join(

--- a/academy/manager.py
+++ b/academy/manager.py
@@ -26,6 +26,7 @@ from academy.exchange import ExchangeFactory
 from academy.exchange import UserExchangeClient
 from academy.exchange.transport import AgentRegistration
 from academy.exchange.transport import ExchangeTransportT
+from academy.handle import exchange_context
 from academy.handle import RemoteHandle
 from academy.identifier import AgentId
 from academy.identifier import UserId
@@ -154,6 +155,9 @@ class Manager(Generic[ExchangeTransportT], NoPickleMixin):
         logger.info('Initialized manager (%s)', self.user_id)
 
     async def __aenter__(self) -> Self:
+        self.exchange_context_token = exchange_context.set(
+            self.exchange_client,
+        )
         return self
 
     async def __aexit__(
@@ -162,6 +166,7 @@ class Manager(Generic[ExchangeTransportT], NoPickleMixin):
         exc_value: BaseException | None,
         exc_traceback: TracebackType | None,
     ) -> None:
+        exchange_context.reset(self.exchange_context_token)
         await self.close()
 
     def __repr__(self) -> str:

--- a/examples/03-agent-agent/run-03.py
+++ b/examples/03-agent-agent/run-03.py
@@ -54,7 +54,7 @@ async def main() -> int:
         reverser = await manager.launch(Reverser)
         coordinator = await manager.launch(
             Coordinator,
-            args=(lowerer, reverser),
+            args=(lowerer.clone(), reverser.clone()),
         )
 
         text = 'DEADBEEF'

--- a/testing/agents.py
+++ b/testing/agents.py
@@ -6,7 +6,6 @@ from typing import TypeVar
 from academy.agent import action
 from academy.agent import Agent
 from academy.agent import loop
-from academy.handle import Handle
 
 T = TypeVar('T')
 
@@ -19,12 +18,6 @@ class ErrorAgent(Agent):
     @action
     async def fails(self) -> None:
         raise RuntimeError('This action always fails.')
-
-
-class HandleAgent(Agent):
-    def __init__(self, handle: Handle[EmptyAgent]) -> None:
-        super().__init__()
-        self.handle = handle
 
 
 class IdentityAgent(Agent):

--- a/tests/integration/agent_agent_handles_test.py
+++ b/tests/integration/agent_agent_handles_test.py
@@ -50,7 +50,7 @@ async def test_agent_agent_handles() -> None:
         reverser = await manager.launch(Reverser)
         coordinator = await manager.launch(
             Coordinator,
-            args=(lowerer, reverser),
+            args=(lowerer.clone(), reverser.clone()),
         )
 
         text = 'DEADBEEF'

--- a/tests/unit/agent_test.py
+++ b/tests/unit/agent_test.py
@@ -18,10 +18,8 @@ from academy.context import AgentContext
 from academy.exception import AgentNotInitializedError
 from academy.exchange import UserExchangeClient
 from academy.exchange.local import LocalExchangeTransport
-from academy.handle import ProxyHandle
 from academy.identifier import AgentId
 from testing.agents import EmptyAgent
-from testing.agents import HandleAgent
 from testing.agents import IdentityAgent
 from testing.agents import WaitAgent
 from testing.constant import TEST_SLEEP_INTERVAL
@@ -136,7 +134,6 @@ async def test_agent_empty() -> None:
 
     assert len(agent._agent_actions()) == 0
     assert len(agent._agent_loops()) == 0
-    assert len(agent._agent_handles()) == 0
 
     await agent.agent_on_shutdown()
 
@@ -310,18 +307,6 @@ def test_agent_action_decorator_name_clash_error() -> None:
         match='The name of the decorated method is "shutdown" which clashes',
     ):
         action(_TestAgent.shutdown)
-
-
-@pytest.mark.asyncio
-async def test_agent_handles() -> None:
-    handle = ProxyHandle(EmptyAgent())
-    agent = HandleAgent(handle)
-    await agent.agent_on_startup()
-
-    handles = agent._agent_handles()
-    assert set(handles) == {'handle'}
-
-    await agent.agent_on_shutdown()
 
 
 class A(Agent): ...

--- a/tests/unit/exchange/client_test.py
+++ b/tests/unit/exchange/client_test.py
@@ -100,21 +100,6 @@ async def test_client_get_factory(client: UserExchangeClient[Any]) -> None:
 
 
 @pytest.mark.asyncio
-async def test_client_get_handle(client: UserExchangeClient[Any]) -> None:
-    registration = await client.register_agent(EmptyAgent)
-    async with client.get_handle(registration.agent_id):
-        pass
-
-
-@pytest.mark.asyncio
-async def test_client_get_handle_type_error(
-    client: UserExchangeClient[Any],
-) -> None:
-    with pytest.raises(TypeError):
-        client.get_handle(UserId.new())  # type: ignore[arg-type]
-
-
-@pytest.mark.asyncio
 async def test_client_get_status(client: UserExchangeClient[Any]) -> None:
     uid = UserId.new()
     assert await client.status(uid) == MailboxStatus.MISSING
@@ -170,10 +155,8 @@ async def test_agent_handle_process_response(
             registration,
             _handler,
         ) as agent_client:
-            handle: RemoteHandle[EmptyAgent] = agent_client.get_handle(
-                AgentId.new(),
-            )
-
+            handle: RemoteHandle[EmptyAgent] = RemoteHandle(AgentId.new())
+            assert handle.exchange == agent_client
             message = Message.create(
                 src=user_client.client_id,
                 dest=agent_client.client_id,

--- a/tests/unit/handle_test.py
+++ b/tests/unit/handle_test.py
@@ -128,6 +128,8 @@ async def test_agent_remote_handle_serialize(
         assert reconstructed._exchange is None
         # exchange is returned from context variable
         assert reconstructed.exchange == exchange_client
+        assert str(reconstructed) == str(handle)
+        assert repr(reconstructed) == repr(handle)
 
 
 @pytest.mark.asyncio

--- a/tests/unit/handle_test.py
+++ b/tests/unit/handle_test.py
@@ -142,8 +142,16 @@ async def test_agent_remote_handle_context() -> None:
         with pytest.raises(HandleNotBoundError):
             assert handle.exchange == exchange_client
 
+        with pytest.raises(HandleNotBoundError):
+            assert handle.client_id is not None
+
+        unbound_repr = repr(handle)
+        unbound_str = str(handle)
+
         exchange_context.set(exchange_client)
         assert handle.exchange == exchange_client
+        assert unbound_repr != repr(handle)
+        assert unbound_str != str(handle)
 
 
 @pytest.mark.asyncio

--- a/tests/unit/runtime_test.py
+++ b/tests/unit/runtime_test.py
@@ -12,6 +12,7 @@ from academy.agent import Agent
 from academy.agent import loop
 from academy.context import ActionContext
 from academy.exception import ActionCancelledError
+from academy.exception import HandleReuseError
 from academy.exchange import UserExchangeClient
 from academy.exchange.local import LocalExchangeTransport
 from academy.exchange.transport import MailboxStatus
@@ -523,7 +524,6 @@ async def test_agent_exchnage_context(
     proxy_handle = ProxyHandle(EmptyAgent())
     unbound_handle = RemoteHandle(
         (await exchange_client.register_agent(EmptyAgent)).agent_id,
-        None,
     )
 
     async def _request_handler(_: Any) -> None:  # pragma: no cover
@@ -545,18 +545,13 @@ async def test_agent_exchnage_context(
 class HandleBindingAgent(Agent):
     def __init__(
         self,
-        unbound: RemoteHandle[EmptyAgent],
-        agent_bound: RemoteHandle[EmptyAgent],
-        self_bound: RemoteHandle[EmptyAgent],
+        handle: RemoteHandle[EmptyAgent],
     ) -> None:
-        self.unbound = unbound
-        self.agent_bound = agent_bound
-        self.self_bound = self_bound
+        self.handle = handle
 
     async def agent_on_startup(self) -> None:
-        assert isinstance(self.unbound.client_id, AgentId)
-        assert self.unbound.client_id == self.agent_bound.client_id
-        assert self.unbound.client_id == self.self_bound.client_id
+        assert isinstance(self.handle.client_id, AgentId)
+        assert self.handle.client_id == self.agent_id
 
 
 @pytest.mark.asyncio
@@ -567,41 +562,53 @@ async def test_runtime_bind_handles(
     main_agent_reg = await exchange_client.register_agent(HandleBindingAgent)
     remote_agent1_reg = await exchange_client.register_agent(EmptyAgent)
     remote_agent1_id = remote_agent1_reg.agent_id
-    remote_agent2_reg = await exchange_client.register_agent(EmptyAgent)
-
-    async def _request_handler(_: Any) -> None:  # pragma: no cover
-        pass
-
-    main_agent_client = await factory.create_agent_client(
-        main_agent_reg,
-        _request_handler,
-    )
-    remote_agent2_client = await factory.create_agent_client(
-        remote_agent2_reg,
-        _request_handler,
-    )
 
     agent = HandleBindingAgent(
-        unbound=RemoteHandle(remote_agent1_id, None),
-        agent_bound=RemoteHandle(remote_agent1_id, remote_agent2_client),
-        self_bound=RemoteHandle(remote_agent1_id, main_agent_client),
+        handle=RemoteHandle(remote_agent1_id),
     )
-
-    # The agent is going to create it's own exchange client so we'd end up
-    # with two clients for the same agent. Close this one as we just used
-    # it to mock a handle already bound to the agent.
-    await main_agent_client.close()
 
     async with Runtime(
         agent,
         exchange_factory=factory,
         registration=main_agent_reg,
     ) as runtime:
-        # The self-bound remote handles should be ignored.
         assert runtime._exchange_client is not None
-        assert len(runtime._exchange_client._handles) == 3  # noqa: PLR2004
+        assert len(runtime._exchange_client._handles) == 1
 
-    await remote_agent2_client.close()
+
+@pytest.mark.asyncio
+async def test_runtime_handle_reuse(
+    exchange_client: UserExchangeClient[LocalExchangeTransport],
+) -> None:
+    factory = exchange_client.factory()
+    main_agent_reg = await exchange_client.register_agent(HandleBindingAgent)
+    remote_agent1_reg = await exchange_client.register_agent(EmptyAgent)
+    remote_agent1_id = remote_agent1_reg.agent_id
+
+    async def _request_handler(_: Any) -> None:  # pragma: no cover
+        pass
+
+    agent_client = await factory.create_agent_client(
+        main_agent_reg,
+        _request_handler,
+    )
+
+    remote = RemoteHandle(remote_agent1_id, agent_client)
+    agent = HandleBindingAgent(
+        handle=remote,
+    )
+
+    await agent_client.close()
+
+    # A handle listening on two exchanges is never supported
+    # Even though agent client and agent have the same mailbox id
+    # They have different message listening loops
+    with pytest.raises(HandleReuseError):
+        await Runtime(
+            agent,
+            exchange_factory=factory,
+            registration=main_agent_reg,
+        ).run_until_complete()
 
 
 class ShutdownAgent(Agent):


### PR DESCRIPTION
## Summary
In a handle read the exchange client from a contextvar by default, using only the set exchange when the contextvar is not present. 

This change limits the need for re-binding handles based on the current use. Previously, we had to search for handles as properties of agents and bind them to the agent exchange. This got tricky very fast. We needed a custom type to search through lists or dictionaries of handles and couldn't find handles that were for instance passed into tools. A typical use case for a client handle will be inside of a context (either the exchange client context or the manager context). In both of these cases we can set the exchange client as a contextvar upon entering the client. A typical use case for an agent will only use a handle after an agent is started, where we set the contextvar.

The atypical use cases get messy. Particularly because an ExchangeClient must also keep track of the handles that are using if to send messages. If for instance a single handle is used to execute two actions with two different ExchangeClients, it will now belong to both of them and may be closed by both of them.

## Related Issue
- Fixes #169 

## Changes
- [x] Breaking (backwards incompatible changes to public interfaces)
- [x] Bug fix (non-breaking change which fixes an issue)

## Pull Request Checklist

Please confirm the PR meets the following requirements.
- [x] Relevant tags are added based on the types of changes.
- [x] Code changes pass `pre-commit` (e.g., ruff, mypy, etc.).
- [x] Tests have been added to show the fix is effective or that the new feature works.
- [x] New and existing unit tests pass locally with the changes.
- [x] Docs have been updated and reviewed if relevant.
