### PR TITLE
Allow handles to be used by multiple clients

### DIFF
--- a/academy/context.py
+++ b/academy/context.py
@@ -55,7 +55,6 @@ class ActionContext:
         if self._source_handle is None:
             self._source_handle = RemoteHandle(
                 self.source_id,
-                self._exchange_client,
             )
         return self._source_handle
 

--- a/academy/context.py
+++ b/academy/context.py
@@ -53,9 +53,7 @@ class ActionContext:
                 'Cannot create handle to source because it is a user entity.',
             )
         if self._source_handle is None:
-            self._source_handle = RemoteHandle(
-                self.source_id,
-            )
+            self._source_handle = RemoteHandle(self.source_id)
         return self._source_handle
 
     def is_agent_source(self) -> bool:

--- a/academy/exception.py
+++ b/academy/exception.py
@@ -102,52 +102,20 @@ class UnauthorizedError(ExchangeError):
     pass
 
 
-class HandleClosedError(Exception):
-    """Agent handle has been closed."""
-
-    def __init__(
-        self,
-        agent_id: AgentId[Any],
-        client_id: EntityId | None,
-    ) -> None:
-        message = (
-            f'Handle to {agent_id} bound to {client_id} has been closed.'
-            if client_id is not None
-            else f'Handle to {agent_id} has been closed.'
-        )
-        super().__init__(message)
-
-
 class ExchangeClientNotFoundError(Exception):
     """Handle to agent can not find an exchange client to use.
 
     A [`RemoteHandle`][academy.handle.RemoteHandle] is
-    initialized with a target agent ID, but was not initialized with an
-    exchange client, and is not used in a context where an exchange
-    client could be inferred. Typically this can be resolved by using a
-    [`ExchangeClient`][academy.exchange.ExchangeClient] or
-    [`Manager`][academy.manager.Manager] as a context manager.
+    initialized with a target agent ID is not used in a context where an
+    exchange client could be inferred. Typically this can be resolved by
+    using a [`ExchangeClient`][academy.exchange.ExchangeClient] or
+    [`Manager`][academy.manager.Manager] as a context manager. If this error
+    happens within an agent, it likely means the agent was not started.
     """
 
     def __init__(self, aid: AgentId[Any]) -> None:
         super().__init__(
             f'Handle to {aid} can not find an exchange client to use. See the '
-            'exception docstring for troubleshooting.',
-        )
-
-
-class HandleReuseError(Exception):
-    """Handle to agent used by multiple clients/agents.
-
-    A [`RemoteHandle`][academy.handle.RemoteHandle] is used by multiple
-    clients or agents. This means the handle would try to send and
-    receive at multiple mailbox addresses. This can be resolved by
-    calling handle.clone() (usually at agent initialization).
-    """
-
-    def __init__(self, aid: AgentId[Any]) -> None:
-        super().__init__(
-            f'Handle to {aid} used by multiple clients/agents. See the '
             'exception docstring for troubleshooting.',
         )
 

--- a/academy/exchange/__init__.py
+++ b/academy/exchange/__init__.py
@@ -200,12 +200,6 @@ class ExchangeClient(abc.ABC, Generic[ExchangeTransportT]):
         """Close the transport."""
         ...
 
-    async def _close_handles(self) -> None:
-        """Close all handles created by this client."""
-        for key in tuple(self._handles):
-            handle = self._handles.pop(key)
-            await handle.close(wait_futures=False)
-
     async def discover(
         self,
         agent: type[Agent],
@@ -358,7 +352,6 @@ class AgentExchangeClient(
             if self._closed:
                 return
 
-            await self._close_handles()
             await self._transport.close()
             self._closed = True
             logger.info('Closed exchange client for %s', self.client_id)
@@ -425,7 +418,6 @@ class UserExchangeClient(ExchangeClient[ExchangeTransportT]):
             if self._closed:
                 return
 
-            await self._close_handles()
             await self._transport.terminate(self.client_id)
             logger.info(f'Terminated mailbox for {self.client_id}')
             await self._stop_listener_task()

--- a/academy/exchange/__init__.py
+++ b/academy/exchange/__init__.py
@@ -15,6 +15,7 @@ from typing import Generic
 from typing import Protocol
 from typing import runtime_checkable
 from typing import TypeVar
+from weakref import WeakValueDictionary
 
 if sys.version_info >= (3, 11):  # pragma: >=3.11 cover
     from typing import TypeAlias
@@ -166,7 +167,9 @@ class ExchangeClient(abc.ABC, Generic[ExchangeTransportT]):
         transport: ExchangeTransportT,
     ) -> None:
         self._transport = transport
-        self._handles: dict[uuid.UUID, RemoteHandle[Any]] = {}
+        self._handles: WeakValueDictionary[uuid.UUID, RemoteHandle[Any]] = (
+            WeakValueDictionary()
+        )
         self._close_lock = asyncio.Lock()
         self._closed = False
 
@@ -412,7 +415,7 @@ class UserExchangeClient(ExchangeClient[ExchangeTransportT]):
         """Close the user client.
 
         This terminates the user's mailbox, closes the underlying exchange
-        transport, and closes all handles produced by this client.
+        transport.
         """
         async with self._close_lock:
             if self._closed:

--- a/academy/handle.py
+++ b/academy/handle.py
@@ -7,6 +7,7 @@ import sys
 import time
 import uuid
 from contextvars import ContextVar
+from pickle import PicklingError
 from typing import Any
 from typing import Generic
 from typing import Protocol
@@ -250,6 +251,7 @@ class RemoteHandle(Generic[AgentT]):
     def __init__(
         self,
         agent_id: AgentId[AgentT],
+        *,
         exchange: ExchangeClient[Any] | None = None,
         ignore_context: bool = False,
     ) -> None:
@@ -301,14 +303,11 @@ class RemoteHandle(Generic[AgentT]):
         type[RemoteHandle[Any]],
         tuple[Any, ...],
     ]:
-        return (
-            RemoteHandle,
-            (
-                self.agent_id,
-                self._exchange,
-                self.ignore_context,
-            ),
-        )
+        if self.ignore_context:
+            raise PicklingError(
+                'Handle with ignore_context=True is not pickle-able',
+            )
+        return (RemoteHandle, (self.agent_id,))
 
     def __repr__(self) -> str:
         return (

--- a/academy/handle.py
+++ b/academy/handle.py
@@ -6,10 +6,7 @@ import logging
 import sys
 import time
 import uuid
-from collections.abc import Iterable
-from collections.abc import Mapping
 from contextvars import ContextVar
-from types import TracebackType
 from typing import Any
 from typing import Generic
 from typing import Protocol
@@ -23,17 +20,13 @@ else:  # pragma: <3.10 cover
     from typing_extensions import ParamSpec
 
 if sys.version_info >= (3, 11):  # pragma: >=3.11 cover
-    from typing import Self
+    pass
 else:  # pragma: <3.11 cover
-    from typing_extensions import Self
+    pass
 
 from academy.exception import AgentTerminatedError
 from academy.exception import ExchangeClientNotFoundError
-from academy.exception import HandleClosedError
-from academy.exception import HandleReuseError
 from academy.identifier import AgentId
-from academy.identifier import EntityId
-from academy.identifier import UserId
 from academy.message import ActionRequest
 from academy.message import ActionResponse
 from academy.message import ErrorResponse
@@ -77,11 +70,6 @@ class Handle(Protocol[AgentT]):
         """ID of the agent this is a handle to."""
         ...
 
-    @property
-    def client_id(self) -> EntityId:
-        """ID of the client for this handle."""
-        ...
-
     async def action(self, action: str, /, *args: Any, **kwargs: Any) -> R:
         """Invoke an action on the agent.
 
@@ -98,22 +86,6 @@ class Handle(Protocol[AgentT]):
                 typically indicates the agent shutdown for another reason
                 (it self terminated or via another handle).
             Exception: Any exception raised by the action.
-            HandleClosedError: If the handle was closed.
-        """
-        ...
-
-    async def close(
-        self,
-        wait_futures: bool = True,
-        *,
-        timeout: float | None = None,
-    ) -> None:
-        """Close this handle.
-
-        Args:
-            wait_futures: Wait to return until all pending futures are done
-                executing. If `False`, pending futures are cancelled.
-            timeout: Optional timeout used when `wait=True`.
         """
         ...
 
@@ -134,7 +106,6 @@ class Handle(Protocol[AgentT]):
             AgentTerminatedError: If the agent's mailbox was closed. This
                 typically indicates the agent shutdown for another reason
                 (it self terminated or via another handle).
-            HandleClosedError: If the handle was closed.
             TimeoutError: If the timeout is exceeded.
         """
         ...
@@ -152,45 +123,8 @@ class Handle(Protocol[AgentT]):
             AgentTerminatedError: If the agent's mailbox was closed. This
                 typically indicates the agent shutdown for another reason
                 (it self terminated or via another handle).
-            HandleClosedError: If the handle was closed.
         """
         ...
-
-
-class HandleDict(dict[K, Handle[AgentT]]):
-    """Dictionary mapping keys to handles.
-
-    Tip:
-        The `HandleDict` is required when storing a mapping of handles as
-        attributes of a `Agent` so that those handles get bound to the
-        correct agent when running.
-    """
-
-    def __init__(
-        self,
-        values: Mapping[K, Handle[AgentT]]
-        | Iterable[tuple[K, Handle[AgentT]]] = (),
-        /,
-        **kwargs: dict[str, Handle[AgentT]],
-    ) -> None:
-        super().__init__(values, **kwargs)
-
-
-class HandleList(list[Handle[AgentT]]):
-    """List of handles.
-
-    Tip:
-        The `HandleList` is required when storing a list of handles as
-        attributes of a `Agent` so that those handles get bound to the
-        correct agent when running.
-    """
-
-    def __init__(
-        self,
-        iterable: Iterable[Handle[AgentT]] = (),
-        /,
-    ) -> None:
-        super().__init__(iterable)
 
 
 class ProxyHandle(Generic[AgentT]):
@@ -205,9 +139,7 @@ class ProxyHandle(Generic[AgentT]):
     def __init__(self, agent: AgentT) -> None:
         self.agent = agent
         self.agent_id: AgentId[AgentT] = AgentId.new()
-        self.client_id: EntityId = UserId.new()
         self._agent_closed = False
-        self._handle_closed = False
 
     def __repr__(self) -> str:
         return f'{type(self).__name__}(agent={self.agent!r})'
@@ -244,33 +176,12 @@ class ProxyHandle(Generic[AgentT]):
                 typically indicates the agent shutdown for another reason
                 (it self terminated or via another handle).
             Exception: Any exception raised by the action.
-            HandleClosedError: If the handle was closed.
         """
         if self._agent_closed:
             raise AgentTerminatedError(self.agent_id)
-        elif self._handle_closed:
-            raise HandleClosedError(self.agent_id, self.client_id)
 
         method = getattr(self.agent, action)
         return await method(*args, **kwargs)
-
-    async def close(
-        self,
-        wait_futures: bool = True,
-        *,
-        timeout: float | None = None,
-    ) -> None:
-        """Close this handle.
-
-        Note:
-            This is a no-op for proxy handles.
-
-        Args:
-            wait_futures: Wait to return until all pending futures are done
-                executing. If `False`, pending futures are cancelled.
-            timeout: Optional timeout used when `wait=True`.
-        """
-        self._handle_closed = True
 
     async def ping(self, *, timeout: float | None = None) -> float:
         """Ping the agent.
@@ -292,13 +203,10 @@ class ProxyHandle(Generic[AgentT]):
             AgentTerminatedError: If the agent's mailbox was closed. This
                 typically indicates the agent shutdown for another reason
                 (it self terminated or via another handle).
-            HandleClosedError: If the handle was closed.
             TimeoutError: If the timeout is exceeded.
         """
         if self._agent_closed:
             raise AgentTerminatedError(self.agent_id)
-        elif self._handle_closed:
-            raise HandleClosedError(self.agent_id, self.client_id)
         return 0
 
     async def shutdown(self, *, terminate: bool | None = None) -> None:
@@ -314,55 +222,35 @@ class ProxyHandle(Generic[AgentT]):
             AgentTerminatedError: If the agent's mailbox was closed. This
                 typically indicates the agent shutdown for another reason
                 (it self terminated or via another handle).
-            HandleClosedError: If the handle was closed.
         """
         if self._agent_closed:
             raise AgentTerminatedError(self.agent_id)
-        elif self._handle_closed:
-            raise HandleClosedError(self.agent_id, self.client_id)
         self._agent_closed = True if terminate is None else terminate
 
 
-exchange_context: ContextVar[ExchangeClient[Any] | None] = ContextVar(
+exchange_context: ContextVar[ExchangeClient[Any]] = ContextVar(
     'exchange_context',
-    default=None,
 )
 
 
 class RemoteHandle(Generic[AgentT]):
-    """Handle to a remote agent bound to an exchange client.
+    """Handle to a remote agent.
 
     Args:
-        exchange: Exchange client used for agent communication.
         agent_id: EntityId of the target agent of this handle.
     """
 
     def __init__(
         self,
         agent_id: AgentId[AgentT],
-        exchange: ExchangeClient[Any] | None = None,
     ) -> None:
         self.agent_id = agent_id
-        self._exchange = exchange
-
-        if (
-            self._exchange is not None
-            and self.agent_id == self._exchange.client_id
-        ):
-            raise ValueError(
-                'Cannot create handle to self. The IDs of the exchange '
-                f'client and the target agent are the same: {self.agent_id}.',
-            )
+        self._registered_exchanges: set[ExchangeClient[Any]] = set()
 
         # Unique identifier for each handle object; used to disambiguate
         # messages when multiple handles are bound to the same mailbox.
         self.handle_id = uuid.uuid4()
-
-        if self._exchange is not None:
-            self._exchange.register_handle(self)
-
         self._futures: dict[uuid.UUID, asyncio.Future[Any]] = {}
-        self._closed = False
 
     @property
     def exchange(self) -> ExchangeClient[Any]:
@@ -375,70 +263,33 @@ class RemoteHandle(Generic[AgentT]):
             HandleNotBoundError: If the exchange client can't be found.
 
         """
-        exchange = exchange_context.get()
-        if self._exchange is not None:
-            if exchange is not None and self._exchange != exchange:
-                raise HandleReuseError(self.agent_id)
-            return self._exchange
+        try:
+            exchange = exchange_context.get()
+        except LookupError as e:
+            raise ExchangeClientNotFoundError(self.agent_id) from e
 
-        if exchange is None:
-            raise ExchangeClientNotFoundError(self.agent_id)
-
-        self._exchange = exchange
-        self._exchange.register_handle(self)
         return exchange
-
-    @property
-    def client_id(self) -> EntityId:
-        """ID of the client for this handle."""
-        return self.exchange.client_id
-
-    async def __aenter__(self) -> Self:
-        return self
-
-    async def __aexit__(
-        self,
-        exc_type: type[BaseException] | None,
-        exc_value: BaseException | None,
-        exc_traceback: TracebackType | None,
-    ) -> None:
-        await self.close()
 
     def __reduce__(
         self,
     ) -> tuple[
         type[RemoteHandle[Any]],
-        tuple[AgentId[AgentT],],
+        tuple[Any, ...],
     ]:
         return (RemoteHandle, (self.agent_id,))
 
     def __repr__(self) -> str:
-        try:
-            exchange = self.exchange
-        except ExchangeClientNotFoundError:
-            exchange = None
-        return (
-            f'{type(self).__name__}(agent_id={self.agent_id!r}, '
-            f'exchange={exchange!r})'
-        )
+        return f'{type(self).__name__}(agent_id={self.agent_id!r})'
 
     def __str__(self) -> str:
         name = type(self).__name__
-        try:
-            client_id = self.client_id
-        except ExchangeClientNotFoundError:
-            client_id = None
-        return f'{name}<agent: {self.agent_id}; mailbox: {client_id}>'
+        return f'{name}<agent: {self.agent_id}>'
 
     def __getattr__(self, name: str) -> Any:
         async def remote_method_call(*args: Any, **kwargs: Any) -> R:
             return await self.action(name, *args, **kwargs)
 
         return remote_method_call
-
-    def clone(self) -> RemoteHandle[AgentT]:
-        """Create an unbound copy of this handle."""
-        return RemoteHandle(self.agent_id)
 
     async def _process_response(self, response: Message[Response]) -> None:
         future = self._futures.pop(response.tag, None)
@@ -457,40 +308,17 @@ class RemoteHandle(Generic[AgentT]):
         else:
             raise AssertionError('Unreachable.')
 
-    async def close(
-        self,
-        wait_futures: bool = True,
-        *,
-        timeout: float | None = None,
-    ) -> None:
-        """Close this handle.
+    def _register_with_exchange(self, exchange: ExchangeClient[Any]) -> None:
+        """Register to receive messages from exchange.
 
-        Note:
-            This does not close the exchange client.
+        Typically this will be called internally when sending a message.
 
         Args:
-            wait_futures: Wait to return until all pending futures are done
-                executing. If `False`, pending futures are cancelled.
-            timeout: Optional timeout used when `wait=True`.
+            exchange: Exchange client to listen to.
         """
-        self._closed = True
-
-        if len(self._futures) == 0:
-            return
-        if wait_futures:
-            logger.debug('Waiting on pending futures for %s', self)
-            await asyncio.wait(
-                list(self._futures.values()),
-                timeout=timeout,
-            )
-        else:
-            logger.debug('Cancelling pending futures for %s', self)
-            for future in self._futures:
-                self._futures[future].cancel()
-
-    def closed(self) -> bool:
-        """Check if the handle has been closed."""
-        return self._closed
+        if exchange not in self._registered_exchanges:
+            exchange.register_handle(self)
+            self._registered_exchanges.add(exchange)
 
     async def action(self, action: str, /, *args: Any, **kwargs: Any) -> R:
         """Invoke an action on the agent.
@@ -508,13 +336,12 @@ class RemoteHandle(Generic[AgentT]):
                 typically indicates the agent shutdown for another reason
                 (it self terminated or via another handle).
             Exception: Any exception raised by the action.
-            HandleClosedError: If the handle was closed.
         """
-        if self._closed:
-            raise HandleClosedError(self.agent_id, self.client_id)
+        exchange = self.exchange
+        self._register_with_exchange(exchange)
 
         request = Message.create(
-            src=self.client_id,
+            src=exchange.client_id,
             dest=self.agent_id,
             label=self.handle_id,
             body=ActionRequest(action=action, pargs=args, kargs=kwargs),
@@ -550,14 +377,13 @@ class RemoteHandle(Generic[AgentT]):
             AgentTerminatedError: If the agent's mailbox was closed. This
                 typically indicates the agent shutdown for another reason
                 (it self terminated or via another handle).
-            HandleClosedError: If the handle was closed.
             TimeoutError: If the timeout is exceeded.
         """
-        if self._closed:
-            raise HandleClosedError(self.agent_id, self.client_id)
+        exchange = self.exchange
+        self._register_with_exchange(exchange)
 
         request = Message.create(
-            src=self.client_id,
+            src=exchange.client_id,
             dest=self.agent_id,
             label=self.handle_id,
             body=PingRequest(),
@@ -577,7 +403,7 @@ class RemoteHandle(Generic[AgentT]):
         elapsed = time.perf_counter() - start
         logger.debug(
             'Received ping from %s to %s in %.1f ms',
-            self.client_id,
+            exchange.client_id,
             self.agent_id,
             elapsed * 1000,
         )
@@ -596,13 +422,12 @@ class RemoteHandle(Generic[AgentT]):
             AgentTerminatedError: If the agent's mailbox was closed. This
                 typically indicates the agent shutdown for another reason
                 (it self terminated or via another handle).
-            HandleClosedError: If the handle was closed.
         """
-        if self._closed:
-            raise HandleClosedError(self.agent_id, self.client_id)
+        exchange = self.exchange
+        self._register_with_exchange(exchange)
 
         request = Message.create(
-            src=self.client_id,
+            src=exchange.client_id,
             dest=self.agent_id,
             label=self.handle_id,
             body=ShutdownRequest(terminate=terminate),
@@ -610,6 +435,79 @@ class RemoteHandle(Generic[AgentT]):
         await self.exchange.send(request)
         logger.debug(
             'Sent shutdown request from %s to %s',
-            self.client_id,
+            exchange.client_id,
             self.agent_id,
         )
+
+
+class BoundRemoteHandle(RemoteHandle[AgentT]):
+    """Handle to a remote agent bound to a specific client.
+
+    This handle is fixed to send from a certain mailbox, regardless
+    of where it is used. This is for advanced, non-canonical use.
+    This can be used to send a message from a mailbox where there is
+    no exchange client as part of the context, or the context is
+    ambiguous.
+
+    Args:
+        agent_id: EntityId of the target agent of this handle.
+        exchange: Exchange client used for agent communication.
+    """
+
+    def __init__(
+        self,
+        agent_id: AgentId[AgentT],
+        exchange: ExchangeClient[Any],
+    ) -> None:
+        self.agent_id = agent_id
+        self._exchange = exchange
+
+        # Unique identifier for each handle object; used to disambiguate
+        # messages when multiple handles are bound to the same mailbox.
+        self.handle_id = uuid.uuid4()
+        self._futures: dict[uuid.UUID, asyncio.Future[Any]] = {}
+        self._exchange.register_handle(self)
+
+    @property
+    def exchange(self) -> ExchangeClient[Any]:
+        """Exchange client used to send messages.
+
+        Returns:
+            The ExchangeClient
+
+        Raises:
+            HandleNotBoundError: If the exchange client can't be found.
+
+        """
+        return self._exchange
+
+    def __reduce__(
+        self,
+    ) -> tuple[
+        type[BoundRemoteHandle[Any]],
+        tuple[AgentId[AgentT], ExchangeClient[Any]],
+    ]:
+        return (BoundRemoteHandle, (self.agent_id, self._exchange))
+
+    def __repr__(self) -> str:
+        return (
+            f'{type(self).__name__}(agent_id={self.agent_id!r}, '
+            f'exchange={self.exchange!r})'
+        )
+
+    def __str__(self) -> str:
+        name = type(self).__name__
+        return (
+            f'{name}<agent: {self.agent_id}, '
+            f'client_id: {self.exchange.client_id}>'
+        )
+
+    def _register_with_exchange(self, exchange: ExchangeClient[Any]) -> None:
+        """Register to receive messages from exchange.
+
+        Typically this will be called internally when sending a message.
+
+        Args:
+            exchange: Exchange client to listen to.
+        """
+        return

--- a/academy/handle.py
+++ b/academy/handle.py
@@ -293,7 +293,7 @@ class RemoteHandle(Generic[AgentT]):
 
     async def _process_response(self, response: Message[Response]) -> None:
         future = self._futures.pop(response.tag, None)
-        if future is None or future.cancelled():
+        if future is None or future.cancelled():  # pragma: no cover
             # Response is not associated with any active pending future
             # so safe to ignore it
             return

--- a/academy/manager.py
+++ b/academy/manager.py
@@ -444,7 +444,7 @@ class Manager(Generic[ExchangeTransportT], NoPickleMixin):
         """
         agent_id = agent if isinstance(agent, AgentId) else agent.agent_id
         handle = self._handles.get(agent_id, None)
-        if handle is not None and not handle.closed():
+        if handle is not None:
             return handle
         handle = RemoteHandle(agent_id)
         self._handles[agent_id] = handle

--- a/academy/runtime.py
+++ b/academy/runtime.py
@@ -158,7 +158,7 @@ class Runtime(Generic[AgentT], NoPickleMixin):
         ) = None
         self._exchange_listener_task: asyncio.Task[None] | None = None
         self.exchange_context_token: (
-            contextvars.Token[ExchangeClient[Any] | None] | None
+            contextvars.Token[ExchangeClient[Any]] | None
         ) = None
 
     async def __aenter__(self) -> Self:

--- a/docs/migration.md
+++ b/docs/migration.md
@@ -17,7 +17,7 @@ Please refer to our [Version Policy](version-policy.md) for more details on when
 Previously RemoteHandle was bound to a specific [`ExchangeClient`][academy.exchange.ExchangeClient].
 This client was used for sending messages and receiving responses.
 When starting an agent, the handle had to be bound to a client by searching for all handles in the agent.
-Now the RemoteHandle determines the ExchangeClient from a ContextVariable [`exchange_context`][academy.handle.exchange_context].
+Now the RemoteHandle determines the ExchangeClient from a ContextVariable `exchange_context`.
 This ContextVariable is set when running an agent, or when using the [`Manager`][academy.manager.Manager] or the `ExchangeClient` as context managers.
 Using a `Manager` or `ExchangeClient` not as a context manager is highly discouraged.
 In these cases, `exchange=<exchange_client>` can be passed when creating the handle to set the default exchange when there is no context manager.

--- a/docs/migration.md
+++ b/docs/migration.md
@@ -12,6 +12,18 @@ Please refer to our [Version Policy](version-policy.md) for more details on when
 
 ## Academy v0.3
 
+### Handles are now free from exchange clients
+
+Previously RemoteHandle was bound to a specific [`ExchangeClient`][academy.exchange.ExchangeClient].
+This client was used for sending messages and receiving responses.
+When starting an agent, the handle had to be bound to a client by searching for all handles in the agent.
+Now the RemoteHandle determines the ExchangeClient from a ContextVariable [`exchange_context`][academy.handle.exchange_context].
+This ContextVariable is set when running an agent, or when using the [`Manager`][academy.manager.Manager] or the `ExchangeClient` as context managers.
+Using a `Manager` or `ExchangeClient` not as a context manager is highly discouraged.
+In these cases, `exchange=<exchange_client>` can be passed when creating the handle to set the default exchange when there is no context manager.
+In very specific cases, `ignore_context=True` can be used to create a handle that will send and listen on an exchange different from the current context.
+This only applies if you were creating handles manually, or using the `ExchangeClient.get_handle` method. The interface to handles using the `Manager` is the same.
+
 ### Handle actions are blocking by default
 
 Previously, invoking an action on a [`Handle`][academy.handle.Handle.action] returned a [`Future`][asyncio.Future] to the result.

--- a/examples/03-agent-agent/run-03.py
+++ b/examples/03-agent-agent/run-03.py
@@ -54,7 +54,7 @@ async def main() -> int:
         reverser = await manager.launch(Reverser)
         coordinator = await manager.launch(
             Coordinator,
-            args=(lowerer.clone(), reverser.clone()),
+            args=(lowerer, reverser),
         )
 
         text = 'DEADBEEF'

--- a/testing/agents.py
+++ b/testing/agents.py
@@ -55,10 +55,6 @@ class SleepAgent(Agent):
         self.loop_sleep = loop_sleep
         self.steps = 0
 
-    @action
-    async def sleep(self, sleep: float) -> None:
-        await asyncio.sleep(sleep)
-
     @loop
     async def count(self, shutdown: asyncio.Event) -> None:
         while not shutdown.is_set():

--- a/tests/integration/agent_agent_handles_test.py
+++ b/tests/integration/agent_agent_handles_test.py
@@ -50,7 +50,7 @@ async def test_agent_agent_handles() -> None:
         reverser = await manager.launch(Reverser)
         coordinator = await manager.launch(
             Coordinator,
-            args=(lowerer.clone(), reverser.clone()),
+            args=(lowerer, reverser),
         )
 
         text = 'DEADBEEF'

--- a/tests/unit/exchange/client_test.py
+++ b/tests/unit/exchange/client_test.py
@@ -156,7 +156,7 @@ async def test_agent_handle_process_response(
             _handler,
         ) as agent_client:
             handle: RemoteHandle[EmptyAgent] = RemoteHandle(AgentId.new())
-            assert handle.exchange == agent_client
+            handle._register_with_exchange(agent_client)
             message = Message.create(
                 src=user_client.client_id,
                 dest=agent_client.client_id,

--- a/tests/unit/handle_test.py
+++ b/tests/unit/handle_test.py
@@ -1,18 +1,14 @@
 from __future__ import annotations
 
-import asyncio
-from typing import Any
-
 import pytest
 
 from academy.exception import AgentTerminatedError
 from academy.exception import ExchangeClientNotFoundError
-from academy.exception import HandleClosedError
-from academy.exception import HandleReuseError
 from academy.exchange import UserExchangeClient
 from academy.exchange.local import LocalExchangeFactory
 from academy.exchange.local import LocalExchangeTransport
 from academy.exchange.transport import MailboxStatus
+from academy.handle import BoundRemoteHandle
 from academy.handle import exchange_context
 from academy.handle import ProxyHandle
 from academy.handle import RemoteHandle
@@ -22,7 +18,6 @@ from academy.message import PingRequest
 from testing.agents import CounterAgent
 from testing.agents import EmptyAgent
 from testing.agents import ErrorAgent
-from testing.agents import SleepAgent
 from testing.constant import TEST_SLEEP_INTERVAL
 
 
@@ -70,19 +65,6 @@ async def test_proxy_handle_action_errors() -> None:
 
 
 @pytest.mark.asyncio
-async def test_proxy_handle_closed_errors() -> None:
-    handle = ProxyHandle(EmptyAgent())
-    await handle.close()
-
-    with pytest.raises(HandleClosedError):
-        await handle.action('test')
-    with pytest.raises(HandleClosedError):
-        await handle.ping()
-    with pytest.raises(HandleClosedError):
-        await handle.shutdown()
-
-
-@pytest.mark.asyncio
 async def test_proxy_handle_agent_shutdown_errors() -> None:
     handle = ProxyHandle(EmptyAgent())
     await handle.shutdown()
@@ -96,41 +78,19 @@ async def test_proxy_handle_agent_shutdown_errors() -> None:
 
 
 @pytest.mark.asyncio
-async def test_remote_handle_closed_error(
-    exchange_client: UserExchangeClient[LocalExchangeTransport],
-) -> None:
-    registration = await exchange_client.register_agent(EmptyAgent)
-    handle = RemoteHandle(registration.agent_id, exchange_client)
-    await handle.close()
-    assert handle.closed()
-
-    assert handle.client_id is not None
-    with pytest.raises(HandleClosedError):
-        await handle.action('foo')
-    with pytest.raises(HandleClosedError):
-        await handle.ping()
-    with pytest.raises(HandleClosedError):
-        await handle.shutdown()
-
-
-@pytest.mark.asyncio
 async def test_agent_remote_handle_serialize(
     exchange_client: UserExchangeClient[LocalExchangeTransport],
 ) -> None:
     registration = await exchange_client.register_agent(EmptyAgent)
-    async with RemoteHandle(registration.agent_id, exchange_client) as handle:
-        # Note: don't call pickle.dumps here because ThreadExchange
-        # is not pickleable so we test __reduce__ directly.
-        class_, args = handle.__reduce__()
-        reconstructed = class_(*args)
-        assert isinstance(reconstructed, RemoteHandle)
-        assert reconstructed.agent_id == handle.agent_id
-        # _exchange in handle is empty
-        assert reconstructed._exchange is None
-        # exchange is returned from context variable
-        assert reconstructed.exchange == exchange_client
-        assert str(reconstructed) == str(handle)
-        assert repr(reconstructed) == repr(handle)
+    handle = RemoteHandle(registration.agent_id)
+    # Note: don't call pickle.dumps here because ThreadExchange
+    # is not pickleable so we test __reduce__ directly.
+    class_, args = handle.__reduce__()
+    reconstructed = class_(*args)
+    assert isinstance(reconstructed, RemoteHandle)
+    assert reconstructed.agent_id == handle.agent_id
+    assert str(reconstructed) == str(handle)
+    assert repr(reconstructed) == repr(handle)
 
 
 @pytest.mark.asyncio
@@ -139,86 +99,62 @@ async def test_agent_remote_handle_context() -> None:
     factory = LocalExchangeFactory()
     exchange_client = await factory.create_user_client()
     registration = await exchange_client.register_agent(EmptyAgent)
-    async with RemoteHandle(registration.agent_id) as handle:
-        with pytest.raises(ExchangeClientNotFoundError):
-            assert handle.exchange == exchange_client
+    handle = RemoteHandle(registration.agent_id)
 
-        with pytest.raises(ExchangeClientNotFoundError):
-            assert handle.client_id is not None
-
-        unbound_repr = repr(handle)
-        unbound_str = str(handle)
-
-        exchange_context.set(exchange_client)
+    with pytest.raises(ExchangeClientNotFoundError):
         assert handle.exchange == exchange_client
-        assert unbound_repr != repr(handle)
-        assert unbound_str != str(handle)
+
+    exchange_context.set(exchange_client)
+    assert handle.exchange == exchange_client
 
 
 @pytest.mark.asyncio
-async def test_agent_remote_handle_clone() -> None:
-    # We cannot use the fixture here because the fixture will create context
-    factory = LocalExchangeFactory()
-    exchange_client = await factory.create_user_client()
-    registration = await exchange_client.register_agent(EmptyAgent)
-    async with RemoteHandle(registration.agent_id, exchange_client) as handle:
-        cloned = handle.clone()
+async def test_handle_exchange_registration(
+    exchange_client: UserExchangeClient[LocalExchangeTransport],
+) -> None:
+    assert len(exchange_client._handles) == 0
 
-        with pytest.raises(ExchangeClientNotFoundError):
-            assert cloned.exchange == exchange_client
+    registration = await exchange_client.register_agent(EmptyAgent)
+    handle = RemoteHandle(registration.agent_id)
+
+    assert handle.exchange == exchange_client
+    assert len(exchange_client._handles) == 0
+
+    handle._register_with_exchange(exchange_client)
+    assert len(handle._registered_exchanges) == 1
+    assert len(exchange_client._handles) == 1
+
+    # Registration is idempotent
+    handle._register_with_exchange(exchange_client)
+    assert len(handle._registered_exchanges) == 1
+    assert len(exchange_client._handles) == 1
 
 
 @pytest.mark.asyncio
 async def test_agent_remote_handle_reuse(
-    exchange_client: UserExchangeClient[LocalExchangeTransport],
+    manager: Manager[LocalExchangeTransport],
 ) -> None:
-    registration = await exchange_client.register_agent(EmptyAgent)
-    async with RemoteHandle(
-        registration.agent_id,
-        exchange_client,
-    ) as handle:
-        # Context and exchange match
-        assert handle.exchange == exchange_client
-
-    async with RemoteHandle(registration.agent_id) as handle:
-        # Exchange is inferred
-        assert handle.exchange == exchange_client
-
-        factory = exchange_client.factory()
-        async with await factory.create_user_client() as new_client:
-            # New client sets its own context
-            with pytest.raises(HandleReuseError):
-                assert handle.exchange == new_client
-
-            # Cloning fixes the problem
-            assert handle.clone().exchange == new_client
-
-    async with RemoteHandle(registration.agent_id) as handle:
-        factory = exchange_client.factory()
-        async with await factory.create_user_client() as new_client:
-            # Binding is lazy
-            assert handle.exchange == new_client
-
-
-@pytest.mark.asyncio
-async def test_agent_remote_handle_bind(
-    exchange_client: UserExchangeClient[LocalExchangeTransport],
-) -> None:
-    registration = await exchange_client.register_agent(EmptyAgent)
+    exchange_client = manager.exchange_client
     factory = exchange_client.factory()
+    destination = await manager.launch(CounterAgent)
 
-    async def _handler(_: Any) -> None:  # pragma: no cover
-        pass
+    handle = RemoteHandle(destination.agent_id)
+    assert handle.exchange == exchange_client, 'Client not inferred.'
+    assert handle.handle_id not in exchange_client._handles
 
-    async with await factory.create_agent_client(
-        registration,
-        request_handler=_handler,
-    ) as client:
-        with pytest.raises(
-            ValueError,
-            match='Cannot create handle to self.',
-        ):
-            RemoteHandle(registration.agent_id, client)
+    assert await handle.ping() > 0
+    assert handle.handle_id in exchange_client._handles
+    assert exchange_client in handle._registered_exchanges
+
+    async with await factory.create_user_client() as new_client:
+        # Exchange is updated in the agent
+        assert handle.exchange == new_client
+        assert await handle.ping() > 0
+        assert handle.handle_id in new_client._handles
+        assert new_client in handle._registered_exchanges
+
+    # Exchange is reset after
+    assert handle.exchange == exchange_client
 
 
 @pytest.mark.asyncio
@@ -226,7 +162,7 @@ async def test_client_remote_handle_ping_timeout(
     exchange_client: UserExchangeClient[LocalExchangeTransport],
 ) -> None:
     registration = await exchange_client.register_agent(EmptyAgent)
-    handle = RemoteHandle(registration.agent_id, exchange_client)
+    handle = RemoteHandle(registration.agent_id)
     with pytest.raises(TimeoutError):
         await handle.ping(timeout=TEST_SLEEP_INTERVAL)
 
@@ -244,7 +180,7 @@ async def test_client_remote_handle_log_bad_response(
     await handle.exchange.send(
         Message.create(
             src=handle.agent_id,
-            dest=handle.client_id,
+            dest=handle.exchange.client_id,
             body=PingRequest(),
         ),
     )
@@ -304,41 +240,35 @@ async def test_client_remote_handle_errors(
 
 
 @pytest.mark.asyncio
-async def test_client_remote_handle_wait_futures(
-    manager: Manager[LocalExchangeTransport],
-) -> None:
-    handle = await manager.launch(SleepAgent())
-    sleep_task = asyncio.create_task(handle.sleep(TEST_SLEEP_INTERVAL))
+async def test_bound_remote_handle_serialize() -> None:
+    factory = LocalExchangeFactory()
+    exchange_client = await factory.create_user_client()
+    registration = await exchange_client.register_agent(EmptyAgent)
+    handle = BoundRemoteHandle(registration.agent_id, exchange_client)
 
-    # Need to ensure that sleep_task starts running before closing the handle
-    for _ in range(10):
-        await asyncio.sleep(0)
+    assert repr(exchange_client) in repr(handle)
+    assert str(exchange_client.client_id) in str(handle)
 
-    await handle.close(wait_futures=True)
-    await sleep_task
-
-    # Create a new, non-closed handle to shutdown the agent
-    shutdown_handle = manager.get_handle(handle.agent_id)
-    await shutdown_handle.shutdown()
-    await manager.wait({handle.agent_id})
+    class_, args = handle.__reduce__()
+    reconstructed = class_(*args)
+    assert isinstance(reconstructed, BoundRemoteHandle)
+    assert reconstructed.agent_id == handle.agent_id
+    assert str(reconstructed) == str(handle)
+    assert repr(reconstructed) == repr(handle)
 
 
 @pytest.mark.asyncio
-async def test_client_remote_handle_cancel_futures(
+async def test_bound_remote_handle_message(
     manager: Manager[LocalExchangeTransport],
 ) -> None:
-    handle = await manager.launch(SleepAgent())
-    sleep_task = asyncio.create_task(handle.sleep(TEST_SLEEP_INTERVAL))
+    unbound = await manager.launch(EmptyAgent)
+    handle = BoundRemoteHandle(unbound.agent_id, manager.exchange_client)
+    factory = manager.exchange_client.factory()
+    async with await factory.create_user_client() as new_user:
+        # Bound client still uses outer exchange client
+        assert await handle.ping() > 0
+        assert handle.exchange == manager.exchange_client
 
-    # Need to ensure that sleep_task starts running before closing the handle
-    for _ in range(10):
-        await asyncio.sleep(0)
-
-    await handle.close(wait_futures=False)
-    with pytest.raises(asyncio.CancelledError):
-        await sleep_task
-
-    # Create a new, non-closed handle to shutdown the agent
-    async with manager.get_handle(handle.agent_id) as shutdown_handle:
-        await shutdown_handle.shutdown()
-    await manager.wait({handle.agent_id})
+        # Bound exchange uses inner client
+        assert await unbound.ping() > 0
+        assert unbound.exchange == new_user

--- a/tests/unit/runtime_test.py
+++ b/tests/unit/runtime_test.py
@@ -12,13 +12,10 @@ from academy.agent import Agent
 from academy.agent import loop
 from academy.context import ActionContext
 from academy.exception import ActionCancelledError
-from academy.exception import HandleReuseError
 from academy.exchange import UserExchangeClient
 from academy.exchange.local import LocalExchangeTransport
 from academy.exchange.transport import MailboxStatus
 from academy.handle import Handle
-from academy.handle import HandleDict
-from academy.handle import HandleList
 from academy.handle import ProxyHandle
 from academy.handle import RemoteHandle
 from academy.identifier import AgentId
@@ -504,7 +501,7 @@ async def test_runtime_delay_actions_and_loops_to_after_startup(
 
 
 @pytest.mark.asyncio
-async def test_agent_exchnage_context(
+async def test_agent_exchange_context(
     exchange_client: UserExchangeClient[LocalExchangeTransport],
 ) -> None:
     class _TestAgent(Agent):
@@ -516,8 +513,8 @@ async def test_agent_exchnage_context(
             super().__init__()
             self.direct = handle
             self.proxy = proxy
-            self.sequence = HandleList([handle])
-            self.mapping = HandleDict({'x': handle})
+            self.sequence = [handle]
+            self.mapping = {'x': handle}
 
     factory = exchange_client.factory()
     registration = await exchange_client.register_agent(_TestAgent)
@@ -535,80 +532,14 @@ async def test_agent_exchnage_context(
     ) as agent_client:
         agent = _TestAgent(unbound_handle, proxy_handle)
         assert agent.proxy is proxy_handle
-        assert agent.direct.client_id == agent_client.client_id
+        assert isinstance(agent.direct, RemoteHandle)
+        assert agent.direct.exchange == agent_client
         for handle in agent.sequence:
-            assert handle.client_id == agent_client.client_id
+            assert isinstance(handle, RemoteHandle)
+            assert handle.exchange == agent_client
         for handle in agent.mapping.values():
-            assert handle.client_id == agent_client.client_id
-
-
-class HandleBindingAgent(Agent):
-    def __init__(
-        self,
-        handle: RemoteHandle[EmptyAgent],
-    ) -> None:
-        self.handle = handle
-
-    async def agent_on_startup(self) -> None:
-        assert isinstance(self.handle.client_id, AgentId)
-        assert self.handle.client_id == self.agent_id
-
-
-@pytest.mark.asyncio
-async def test_runtime_bind_handles(
-    exchange_client: UserExchangeClient[LocalExchangeTransport],
-) -> None:
-    factory = exchange_client.factory()
-    main_agent_reg = await exchange_client.register_agent(HandleBindingAgent)
-    remote_agent1_reg = await exchange_client.register_agent(EmptyAgent)
-    remote_agent1_id = remote_agent1_reg.agent_id
-
-    agent = HandleBindingAgent(
-        handle=RemoteHandle(remote_agent1_id),
-    )
-
-    async with Runtime(
-        agent,
-        exchange_factory=factory,
-        registration=main_agent_reg,
-    ) as runtime:
-        assert runtime._exchange_client is not None
-        assert len(runtime._exchange_client._handles) == 1
-
-
-@pytest.mark.asyncio
-async def test_runtime_handle_reuse(
-    exchange_client: UserExchangeClient[LocalExchangeTransport],
-) -> None:
-    factory = exchange_client.factory()
-    main_agent_reg = await exchange_client.register_agent(HandleBindingAgent)
-    remote_agent1_reg = await exchange_client.register_agent(EmptyAgent)
-    remote_agent1_id = remote_agent1_reg.agent_id
-
-    async def _request_handler(_: Any) -> None:  # pragma: no cover
-        pass
-
-    agent_client = await factory.create_agent_client(
-        main_agent_reg,
-        _request_handler,
-    )
-
-    remote = RemoteHandle(remote_agent1_id, agent_client)
-    agent = HandleBindingAgent(
-        handle=remote,
-    )
-
-    await agent_client.close()
-
-    # A handle listening on two exchanges is never supported
-    # Even though agent client and agent have the same mailbox id
-    # They have different message listening loops
-    with pytest.raises(HandleReuseError):
-        await Runtime(
-            agent,
-            exchange_factory=factory,
-            registration=main_agent_reg,
-        ).run_until_complete()
+            assert isinstance(handle, RemoteHandle)
+            assert handle.exchange == agent_client
 
 
 class ShutdownAgent(Agent):

--- a/tests/unit/runtime_test.py
+++ b/tests/unit/runtime_test.py
@@ -563,13 +563,13 @@ async def test_agent_exchange_context(
         agent = _TestAgent(unbound_handle, proxy_handle)
         assert agent.proxy is proxy_handle
         assert isinstance(agent.direct, RemoteHandle)
-        assert agent.direct.exchange == agent_client
+        assert agent.direct.exchange is agent_client
         for handle in agent.sequence:
             assert isinstance(handle, RemoteHandle)
-            assert handle.exchange == agent_client
+            assert handle.exchange is agent_client
         for handle in agent.mapping.values():
             assert isinstance(handle, RemoteHandle)
-            assert handle.exchange == agent_client
+            assert handle.exchange is agent_client
 
 
 class ShutdownAgent(Agent):


### PR DESCRIPTION
## Summary
Follow up to #177. A RemoteHandle is now almost completely decoupled from the exchange client it uses. Every time a message is sent, the handle reads the exchange from the context. This allows the same handle to be used by multiple clients without making copies. The only state that is modified within the handle is a set of registered exchanges. As this set only grows, it should be conflict free. 

(Re-)Introduces BoundRemoteHandle, which is a remote handle with a fixed exchange client. This is for exceptional use cases where the address to send messages might differ from the address set in the context variable.

## Related Issues
- Closes #169 (finally...hopefully)

## Changes

- [x] Breaking (backwards incompatible changes to public interfaces)
- [x] Bug fix (non-breaking change which fixes an issue)

## Pull Request Checklist

Please confirm the PR meets the following requirements.
- [x] Relevant tags are added based on the types of changes.
- [x] Code changes pass `pre-commit` (e.g., ruff, mypy, etc.).
- [x] Tests have been added to show the fix is effective or that the new feature works.
- [x] New and existing unit tests pass locally with the changes.
- [x] Docs have been updated and reviewed if relevant.
