### PR TITLE
Consolidate Handle protocol with RemoteHandle

### DIFF
--- a/academy/context.py
+++ b/academy/context.py
@@ -10,7 +10,6 @@ from typing import TypeVar
 
 from academy.exchange import AgentExchangeClient
 from academy.handle import Handle
-from academy.handle import RemoteHandle
 from academy.identifier import AgentId
 from academy.identifier import EntityId
 from academy.identifier import UserId
@@ -53,7 +52,7 @@ class ActionContext:
                 'Cannot create handle to source because it is a user entity.',
             )
         if self._source_handle is None:
-            self._source_handle = RemoteHandle(self.source_id)
+            self._source_handle = Handle(self.source_id)
         return self._source_handle
 
     def is_agent_source(self) -> bool:

--- a/academy/exception.py
+++ b/academy/exception.py
@@ -105,7 +105,7 @@ class UnauthorizedError(ExchangeError):
 class ExchangeClientNotFoundError(Exception):
     """Handle to agent can not find an exchange client to use.
 
-    A [`RemoteHandle`][academy.handle.RemoteHandle] is
+    A [`Handle`][academy.handle.Handle] is
     initialized with a target agent ID is not used in a context where an
     exchange client could be inferred. Typically this can be resolved by
     using a [`ExchangeClient`][academy.exchange.ExchangeClient] or

--- a/academy/exchange/__init__.py
+++ b/academy/exchange/__init__.py
@@ -35,7 +35,7 @@ from academy.exchange.transport import AgentRegistration
 from academy.exchange.transport import ExchangeTransportT
 from academy.exchange.transport import MailboxStatus
 from academy.handle import exchange_context
-from academy.handle import RemoteHandle
+from academy.handle import Handle
 from academy.identifier import AgentId
 from academy.identifier import EntityId
 from academy.identifier import UserId
@@ -167,7 +167,7 @@ class ExchangeClient(abc.ABC, Generic[ExchangeTransportT]):
         transport: ExchangeTransportT,
     ) -> None:
         self._transport = transport
-        self._handles: WeakValueDictionary[uuid.UUID, RemoteHandle[Any]] = (
+        self._handles: WeakValueDictionary[uuid.UUID, Handle[Any]] = (
             WeakValueDictionary()
         )
         self._close_lock = asyncio.Lock()
@@ -228,7 +228,7 @@ class ExchangeClient(abc.ABC, Generic[ExchangeTransportT]):
         """Get an exchange factory."""
         return self._transport.factory()
 
-    def register_handle(self, handle: RemoteHandle[AgentT]) -> None:
+    def register_handle(self, handle: Handle[AgentT]) -> None:
         """Register an existing handle to receive messages.
 
         Args:

--- a/academy/manager.py
+++ b/academy/manager.py
@@ -27,7 +27,7 @@ from academy.exchange import UserExchangeClient
 from academy.exchange.transport import AgentRegistration
 from academy.exchange.transport import ExchangeTransportT
 from academy.handle import exchange_context
-from academy.handle import RemoteHandle
+from academy.handle import Handle
 from academy.identifier import AgentId
 from academy.identifier import UserId
 from academy.runtime import Runtime
@@ -149,7 +149,7 @@ class Manager(Generic[ExchangeTransportT], NoPickleMixin):
         self._default_executor = default_executor
         self._max_retries = max_retries
 
-        self._handles: dict[AgentId[Any], RemoteHandle[Any]] = {}
+        self._handles: dict[AgentId[Any], Handle[Any]] = {}
         self._acbs: dict[AgentId[Any], _ACB[Any]] = {}
 
         logger.info('Initialized manager (%s)', self.user_id)
@@ -359,7 +359,7 @@ class Manager(Generic[ExchangeTransportT], NoPickleMixin):
         executor: str | None = None,
         name: str | None = None,
         registration: AgentRegistration[AgentT] | None = None,
-    ) -> RemoteHandle[AgentT]:
+    ) -> Handle[AgentT]:
         """Launch a new agent with a specified agent.
 
         Args:
@@ -428,7 +428,7 @@ class Manager(Generic[ExchangeTransportT], NoPickleMixin):
     def get_handle(
         self,
         agent: AgentId[AgentT] | AgentRegistration[AgentT],
-    ) -> RemoteHandle[AgentT]:
+    ) -> Handle[AgentT]:
         """Create a new handle to an agent.
 
         A handle acts like a reference to a remote agent, enabling a user
@@ -446,7 +446,7 @@ class Manager(Generic[ExchangeTransportT], NoPickleMixin):
         handle = self._handles.get(agent_id, None)
         if handle is not None:
             return handle
-        handle = RemoteHandle(agent_id)
+        handle = Handle(agent_id)
         self._handles[agent_id] = handle
         return handle
 
@@ -483,7 +483,7 @@ class Manager(Generic[ExchangeTransportT], NoPickleMixin):
 
     async def shutdown(
         self,
-        agent: AgentId[Any] | RemoteHandle[Any],
+        agent: AgentId[Any] | Handle[Any],
         *,
         blocking: bool = True,
         raise_error: bool = True,
@@ -506,7 +506,7 @@ class Manager(Generic[ExchangeTransportT], NoPickleMixin):
                 launched by this manager.
             TimeoutError: If `timeout` was exceeded while blocking for agent.
         """
-        agent_id = agent.agent_id if isinstance(agent, RemoteHandle) else agent
+        agent_id = agent.agent_id if isinstance(agent, Handle) else agent
 
         if agent_id not in self._acbs:
             raise BadEntityIdError(agent_id) from None
@@ -526,7 +526,7 @@ class Manager(Generic[ExchangeTransportT], NoPickleMixin):
 
     async def wait(
         self,
-        agents: Iterable[AgentId[Any] | RemoteHandle[Any]],
+        agents: Iterable[AgentId[Any] | Handle[Any]],
         *,
         raise_error: bool = False,
         return_when: str = asyncio.ALL_COMPLETED,

--- a/docs/get-started.md
+++ b/docs/get-started.md
@@ -63,7 +63,7 @@ if __name__ == '__main__':
 4. The [local exchange][academy.exchange.local.LocalExchangeFactory] manages message passing between users and agents running in a single process. Factories are used to create clients to the exchange.
 5. The manager uses an [`Executor`][concurrent.futures.Executor] to run agents concurrently across parallel/distributed resources. Here, a [`ThreadPoolExecutor`][concurrent.futures.Executor] runs agents in different threads of the main process.
 6. An instantiated agent (here, `ExampleAgent`) can be launched with [`Manager.launch()`][academy.manager.Manager.launch], returning a handle to the remote agent.
-7. Interact with running agents via a [`RemoteHandle`][academy.handle.RemoteHandle]. Invoking an action returns the result.
+7. Interact with running agents via a [`Handle`][academy.handle.Handle]. Invoking an action returns the result.
 8. Agents can be shutdown via a handle or the manager.
 
 Running this script with logging enabled produces the following output:

--- a/docs/migration.md
+++ b/docs/migration.md
@@ -13,7 +13,7 @@ Please refer to our [Version Policy](version-policy.md) for more details on when
 ## Academy v0.3
 
 ### Handles are now free from exchange clients
-
+The Handle protocol has been removed and RemoteHandle has been renamed Handle. ProxyHandle is now a subclass of RemoteHandle. Handle
 Previously RemoteHandle was bound to a specific [`ExchangeClient`][academy.exchange.ExchangeClient].
 This client was used for sending messages and receiving responses.
 When starting an agent, the handle had to be bound to a client by searching for all handles in the agent.

--- a/tests/unit/exchange/client_test.py
+++ b/tests/unit/exchange/client_test.py
@@ -12,7 +12,7 @@ from academy.exception import BadEntityIdError
 from academy.exchange import ExchangeFactory
 from academy.exchange import MailboxStatus
 from academy.exchange import UserExchangeClient
-from academy.handle import RemoteHandle
+from academy.handle import Handle
 from academy.identifier import AgentId
 from academy.identifier import UserId
 from academy.message import ErrorResponse
@@ -155,7 +155,7 @@ async def test_agent_handle_process_response(
             registration,
             _handler,
         ) as agent_client:
-            handle: RemoteHandle[EmptyAgent] = RemoteHandle(AgentId.new())
+            handle: Handle[EmptyAgent] = Handle(AgentId.new())
             handle._register_with_exchange(agent_client)
             message = Message.create(
                 src=user_client.client_id,

--- a/tests/unit/runtime_test.py
+++ b/tests/unit/runtime_test.py
@@ -17,7 +17,6 @@ from academy.exchange.local import LocalExchangeTransport
 from academy.exchange.transport import MailboxStatus
 from academy.handle import Handle
 from academy.handle import ProxyHandle
-from academy.handle import RemoteHandle
 from academy.identifier import AgentId
 from academy.identifier import EntityId
 from academy.message import ActionRequest
@@ -549,7 +548,7 @@ async def test_agent_exchange_context(
     factory = exchange_client.factory()
     registration = await exchange_client.register_agent(_TestAgent)
     proxy_handle = ProxyHandle(EmptyAgent())
-    unbound_handle = RemoteHandle(
+    unbound_handle = Handle(
         (await exchange_client.register_agent(EmptyAgent)).agent_id,
     )
 
@@ -562,13 +561,13 @@ async def test_agent_exchange_context(
     ) as agent_client:
         agent = _TestAgent(unbound_handle, proxy_handle)
         assert agent.proxy is proxy_handle
-        assert isinstance(agent.direct, RemoteHandle)
+        assert isinstance(agent.direct, Handle)
         assert agent.direct.exchange is agent_client
         for handle in agent.sequence:
-            assert isinstance(handle, RemoteHandle)
+            assert isinstance(handle, Handle)
             assert handle.exchange is agent_client
         for handle in agent.mapping.values():
-            assert isinstance(handle, RemoteHandle)
+            assert isinstance(handle, Handle)
             assert handle.exchange is agent_client
 
 


### PR DESCRIPTION
## Summary
The Handle protocol was verbose, and seemed unnecessary. This PR removes that protocol and replaces it with the concrete implementation of RemoteHandle. RemoteHandle covers 95% of the code that we write. ProxyHandle now inherits from Handle (RemoteHandle).

## Changes

- [x] Breaking (backwards incompatible changes to public interfaces)

## Pull Request Checklist

Please confirm the PR meets the following requirements.
- [x] Relevant tags are added based on the types of changes.
- [x] Code changes pass `pre-commit` (e.g., ruff, mypy, etc.).
- [x] Tests have been added to show the fix is effective or that the new feature works.
- [x] New and existing unit tests pass locally with the changes.
- [x] Docs have been updated and reviewed if relevant.
