### PR TITLE
Auth ID Cacheing

### DIFF
--- a/academy/exchange/cloud/authenticate.py
+++ b/academy/exchange/cloud/authenticate.py
@@ -2,13 +2,17 @@
 
 from __future__ import annotations
 
+import asyncio
+import threading
 import uuid
 from collections.abc import Mapping
-from threading import Lock
+from concurrent.futures import ThreadPoolExecutor
 from typing import Protocol
 from typing import runtime_checkable
 
 import globus_sdk
+from cachetools import cached
+from cachetools import TTLCache
 
 from academy.exchange.cloud.config import ExchangeAuthConfig
 from academy.exchange.cloud.exceptions import ForbiddenError
@@ -20,7 +24,7 @@ from academy.exchange.cloud.login import AcademyExchangeScopes
 class Authenticator(Protocol):
     """Authenticate users from request headers."""
 
-    def authenticate_user(self, headers: Mapping[str, str]) -> uuid.UUID:
+    async def authenticate_user(self, headers: Mapping[str, str]) -> uuid.UUID:
         """Authenticate user from request headers.
 
         Warning:
@@ -43,7 +47,7 @@ class Authenticator(Protocol):
 class NullAuthenticator:
     """Authenticator that implements no authentication."""
 
-    def authenticate_user(self, headers: Mapping[str, str]) -> uuid.UUID:
+    async def authenticate_user(self, headers: Mapping[str, str]) -> uuid.UUID:
         """Authenticate user from request headers.
 
         Args:
@@ -69,9 +73,10 @@ class GlobusAuthenticator:
         audience: Intended audience of the token. This should typically be
             the resource server of the the token was issued for. E.g.,
             the UUID of the ProxyStore Relay Server application.
-        auth_client: Optional confidential application authentication client
-            which is used for introspecting client tokens.
     """
+
+    TOKEN_CACHE_LIMIT: int = 1024
+    TOKEN_TTL: int = 60
 
     def __init__(
         self,
@@ -79,20 +84,40 @@ class GlobusAuthenticator:
         client_secret: str | None = None,
         *,
         audience: str = AcademyExchangeScopes.resource_server,
-        auth_client: globus_sdk.ConfidentialAppAuthClient | None = None,
     ) -> None:
-        self.auth_client = (
-            globus_sdk.ConfidentialAppAuthClient(
-                client_id=str(client_id),
-                client_secret=str(client_secret),
-            )
-            if auth_client is None
-            else auth_client
-        )
-        self.auth_client_lock = Lock()
+        self._local_data = threading.local()
+        self.executor = ThreadPoolExecutor()
+        self.client_id = client_id
+        self.client_secret = client_secret
         self.audience = audience
 
-    def authenticate_user(self, headers: Mapping[str, str]) -> uuid.UUID:
+    @property
+    def auth_client(self) -> globus_sdk.ConfidentialAppAuthClient:
+        """A thread local copy of the Globus AuthClient."""
+        try:
+            return self._local_data.auth_client
+        except AttributeError:
+            self._local_data.auth_client = (
+                globus_sdk.ConfidentialAppAuthClient(
+                    client_id=str(self.client_id),
+                    client_secret=str(self.client_secret),
+                )
+            )
+            return self._local_data.auth_client
+
+    @cached(
+        cache=TTLCache(
+            maxsize=TOKEN_CACHE_LIMIT,
+            ttl=TOKEN_TTL,
+        ),
+    )
+    def _token_introspect(
+        self,
+        token: str,
+    ) -> globus_sdk.response.GlobusHTTPResponse:
+        return self.auth_client.oauth2_token_introspect(token)
+
+    async def authenticate_user(self, headers: Mapping[str, str]) -> uuid.UUID:
         """Authenticate a Globus Auth user from request header.
 
         This follows from the [Globus Sample Data Portal](https://github.com/globus/globus-sample-data-portal/blob/30e30cd418ee9b103e04916e19deb9902d3aafd8/service/decorators.py)
@@ -116,8 +141,12 @@ class GlobusAuthenticator:
                 audience.
         """
         token = get_token_from_headers(headers)
-        with self.auth_client_lock:
-            token_meta = self.auth_client.oauth2_token_introspect(token)
+        loop = asyncio.get_running_loop()
+        token_meta = await loop.run_in_executor(
+            self.executor,
+            self._token_introspect,
+            token,
+        )
 
         if not token_meta.get('active'):
             raise ForbiddenError('Token is expired or has been revoked.')

--- a/academy/exchange/cloud/server.py
+++ b/academy/exchange/cloud/server.py
@@ -453,12 +453,8 @@ def authenticate_factory(
         request: Request,
         handler: Callable[[Request], Awaitable[Response]],
     ) -> Response:
-        loop = asyncio.get_running_loop()
         try:
-            # Needs to be run in executor because globus client is blocking
-            client_uuid: uuid.UUID = await loop.run_in_executor(
-                None,
-                authenticator.authenticate_user,
+            client_uuid: uuid.UUID = await authenticator.authenticate_user(
                 request.headers,
             )
         except ForbiddenError:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -66,6 +66,9 @@ docs = [
     "mkdocstrings-python==1.16.10",
     "mike==2.1.3",
 ]
+server = [
+    "cachetools"
+]
 
 [tool.codespell]
 skip = """


### PR DESCRIPTION
## Summary
Added cache and local client to import auth performance. Previously, a `oauth2_token_introspect` call was made for every API call to the cloud hosted server. In addition, the AuthClient was protected by a lock, so only one call could proceed even with asyncio. To fix these issues, I moved the AuthClient to thread local storage and included a cache on the token introspect calls. Preliminary benchmarking on my (very old) laptop shows that this led to a significant speed-up of authentication compared to before. There is more work to be done, but this likely explains most of the performance issues we were having during the tutorial.

Previous benchmark (the variance is likely due to the range of other tasks on my laptop, and the fact that I only ran 1 repetition):
```
Clients: 1      Messages: 100   Time: 33.190674054      Throughput: 3.012894520831475
Clients: 2      Messages: 100   Time: 139.076211315     Throughput: 1.4380604569893767
Clients: 3      Messages: 100   Time: 184.203588142     Throughput: 1.6286327700019294
Clients: 4      Messages: 100   Time: 236.53706735      Throughput: 1.6910668779372604
```

After P.R.
```
Clients: 1      Messages: 100   Time: 0.514027066       Throughput: 194.54228505547215
Clients: 2      Messages: 100   Time: 1.701158491       Throughput: 117.56694103347952
Clients: 3      Messages: 100   Time: 1.406130397       Throughput: 213.35147909472295
Clients: 4      Messages: 100   Time: 1.817344193       Throughput: 220.10139936106202
```

And without auth:
```
Clients: 1      Messages: 100   Time: 0.32993737        Throughput: 303.087825425777
Clients: 2      Messages: 100   Time: 0.880020703       Throughput: 227.26738054934145
Clients: 3      Messages: 100   Time: 1.464129131       Throughput: 204.8999597426902
Clients: 4      Messages: 100   Time: 1.990686387       Throughput: 200.93571876120936
```

## Changes
- [x] Enhancement (non-breaking change or feature addition)
- [x] Refactor (internal code or design clean up)

## Pull Request Checklist

Please confirm the PR meets the following requirements.
- [x] Relevant tags are added based on the types of changes.
- [x] Code changes pass `pre-commit` (e.g., ruff, mypy, etc.).
- [x] Tests have been added to show the fix is effective or that the new feature works.
- [x] New and existing unit tests pass locally with the changes.
- [x] Docs have been updated and reviewed if relevant.
