### PR TITLE
Redis Key Expiration

### DIFF
--- a/academy/exchange/cloud/backend.py
+++ b/academy/exchange/cloud/backend.py
@@ -599,9 +599,6 @@ class RedisBackend:
             await self._client.delete(self._agent_key(uid))
 
         for raw in pending:
-            if raw == _CLOSE_SENTINEL:
-                break
-
             message: Message[Any] = Message.model_deserialize(raw)
             if message.is_request():
                 error = MailboxTerminatedError(uid)

--- a/academy/exchange/cloud/backend.py
+++ b/academy/exchange/cloud/backend.py
@@ -404,6 +404,7 @@ async def _drain_queue(queue: AsyncQueue[Message[Any]]) -> list[Message[Any]]:
 
 
 _CLOSE_SENTINEL = b'<CLOSED>'
+_OWNER_SUFFIX = '_'
 
 
 class RedisBackend:
@@ -416,13 +417,15 @@ class RedisBackend:
         kwargs: Addition arguments to pass to redis session.
     """
 
-    def __init__(
+    def __init__(  # noqa: PLR0913
         self,
         hostname: str = 'localhost',
         port: int = 6379,
         *,
         message_size_limit_kb: int = 1024,
         kwargs: dict[str, Any] | None = None,
+        mailbox_expiration_s: int | None = None,
+        gravestone_expiration_s: int | None = None,
     ) -> None:
         self.message_size_limit = message_size_limit_kb * KB_TO_BYTES
 
@@ -435,6 +438,8 @@ class RedisBackend:
             decode_responses=False,
             **kwargs,
         )
+        self.mailbox_expiration_s = mailbox_expiration_s
+        self.gravestone_expiration_s = gravestone_expiration_s
 
     def _owner_key(self, uid: EntityId) -> str:
         return f'owner:{uid.uid}'
@@ -456,7 +461,28 @@ class RedisBackend:
         owner = await self._client.get(
             self._owner_key(entity),
         )
-        return owner is None or owner == client
+        return owner is None or owner == f'{client}{_OWNER_SUFFIX}'
+
+    async def _update_expirations(
+        self,
+        entity: EntityId,
+    ) -> None:
+        if self.gravestone_expiration_s is None:
+            return
+
+        await self._client.expire(
+            self._active_key(entity),
+            self.gravestone_expiration_s,
+        )
+        await self._client.expire(
+            self._owner_key(entity),
+            self.gravestone_expiration_s,
+        )
+        if isinstance(entity, AgentId):
+            await self._client.expire(
+                self._agent_key(entity),
+                self.gravestone_expiration_s,
+            )
 
     async def check_mailbox(
         self,
@@ -524,8 +550,9 @@ class RedisBackend:
 
         await self._client.set(
             self._owner_key(uid),
-            client,
+            f'{client}{_OWNER_SUFFIX}',
         )
+        await self._update_expirations(uid)
 
     async def terminate(self, client: str, uid: EntityId) -> None:
         """Close a mailbox.
@@ -546,7 +573,9 @@ class RedisBackend:
                 'Client does not have correct permissions.',
             )
 
-        if await self.check_mailbox(client, uid) == MailboxStatus.MISSING:
+        status = await self.check_mailbox(client, uid)
+
+        if status in {MailboxStatus.MISSING, MailboxStatus.TERMINATED}:
             return
 
         await self._client.set(
@@ -555,6 +584,12 @@ class RedisBackend:
         )
 
         pending = await self._client.lrange(self._queue_key(uid), 0, -1)  # type: ignore[misc]
+        if self.gravestone_expiration_s is not None:
+            await self._client.expire(
+                self._active_key(uid),
+                self.gravestone_expiration_s,
+            )
+
         await self._client.delete(self._queue_key(uid))
         # Sending a close sentinel to the queue is a quick way to force
         # the entity waiting on messages to the mailbox to stop blocking.
@@ -643,6 +678,13 @@ class RedisBackend:
         elif status == MailboxStatus.TERMINATED.value:
             raise MailboxTerminatedError(uid)
 
+        await self._update_expirations(uid)
+        if self.mailbox_expiration_s:
+            await self._client.expire(
+                self._queue_key(uid),
+                self.mailbox_expiration_s,
+            )
+
         raw = await self._client.blpop(  # type: ignore[misc]
             [self._queue_key(uid)],
             timeout=_timeout,
@@ -654,7 +696,6 @@ class RedisBackend:
             )
 
         # Only passed one key to blpop to result is [key, item]
-        assert isinstance(raw, (tuple, list))
         assert len(raw) == 2  # noqa: PLR2004
         if raw[1] == _CLOSE_SENTINEL:  # pragma: no cover
             raise MailboxTerminatedError(uid)
@@ -684,15 +725,22 @@ class RedisBackend:
             raise BadEntityIdError(message.dest)
         elif status == MailboxStatus.TERMINATED.value:
             raise MailboxTerminatedError(message.dest)
-        else:
-            serialized = message.model_serialize()
-            if len(serialized) > self.message_size_limit:
-                raise MessageTooLargeError(
-                    len(serialized),
-                    self.message_size_limit,
-                )
 
-            await self._client.rpush(  # type: ignore[misc]
+        serialized = message.model_serialize()
+        if len(serialized) > self.message_size_limit:
+            raise MessageTooLargeError(
+                len(serialized),
+                self.message_size_limit,
+            )
+
+        await self._client.rpush(  # type: ignore[misc]
+            self._queue_key(message.dest),
+            serialized,
+        )
+
+        if self.mailbox_expiration_s:
+            await self._client.expire(
                 self._queue_key(message.dest),
-                serialized,
+                self.mailbox_expiration_s,
+                nx=True,
             )

--- a/academy/exchange/cloud/config.py
+++ b/academy/exchange/cloud/config.py
@@ -92,6 +92,8 @@ class RedisBackendConfig(BaseModel):
     hostname: str = 'localhost'
     port: int = 6379
     message_size_limit_kb: int = Field(default=1024, gt=0, le=1024 * 512)
+    mailbox_expiration_d: float = Field(default=7, gt=0)
+    gravestone_expiration_d: float = Field(default=365, gt=0)
     kwargs: Dict[str, Any] = Field(  # noqa: UP006
         default_factory=dict,
         repr=False,
@@ -105,6 +107,10 @@ class RedisBackendConfig(BaseModel):
             self.port,
             message_size_limit_kb=self.message_size_limit_kb,
             kwargs=self.kwargs,
+            mailbox_expiration_s=int(self.mailbox_expiration_d * 24 * 2600),
+            gravestone_expiration_s=int(
+                self.gravestone_expiration_d * 24 * 3600,
+            ),
         )
 
 

--- a/tests/unit/exchange/cloud/backend_test.py
+++ b/tests/unit/exchange/cloud/backend_test.py
@@ -182,14 +182,15 @@ async def test_redis_backend_message_size(mock_redis) -> None:
 async def test_redis_backend_gravestone_expire(mock_redis) -> None:
     backend = RedisBackend(gravestone_expiration_s=1)
     user_id = str(uuid.uuid4())
-    uid: AgentId[Any] = AgentId.new()
-    await backend.create_mailbox(user_id, uid, ('EmptyAgent',))
+    aid: AgentId[Any] = AgentId.new()
+    await backend.create_mailbox(user_id, aid, ('EmptyAgent',))
     await asyncio.sleep(2)
-    assert await backend.check_mailbox(user_id, uid) == MailboxStatus.MISSING
+    assert await backend.check_mailbox(user_id, aid) == MailboxStatus.MISSING
     agents = await backend.discover(user_id, 'EmptyAgent', True)
     assert len(agents) == 0
 
     # Mailbox does not expire because of get call
+    uid = UserId.new()
     await backend.create_mailbox(user_id, uid)
     message = Message.create(src=uid, dest=uid, body=PingRequest())
     await backend.put(user_id, message)

--- a/tests/unit/exchange/cloud/backend_test.py
+++ b/tests/unit/exchange/cloud/backend_test.py
@@ -182,10 +182,12 @@ async def test_redis_backend_message_size(mock_redis) -> None:
 async def test_redis_backend_gravestone_expire(mock_redis) -> None:
     backend = RedisBackend(gravestone_expiration_s=1)
     user_id = str(uuid.uuid4())
-    uid = UserId.new()
-    await backend.create_mailbox(user_id, uid)
+    uid: AgentId[Any] = AgentId.new()
+    await backend.create_mailbox(user_id, uid, ('EmptyAgent',))
     await asyncio.sleep(2)
     assert await backend.check_mailbox(user_id, uid) == MailboxStatus.MISSING
+    agents = await backend.discover(user_id, 'EmptyAgent', True)
+    assert len(agents) == 0
 
     # Mailbox does not expire because of get call
     await backend.create_mailbox(user_id, uid)

--- a/tests/unit/exchange/cloud/backend_test.py
+++ b/tests/unit/exchange/cloud/backend_test.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import asyncio
 import uuid
 from collections.abc import AsyncGenerator
 from typing import Any
@@ -175,3 +176,58 @@ async def test_redis_backend_message_size(mock_redis) -> None:
     message = Message.create(src=uid, dest=uid, body=PingRequest())
     with pytest.raises(MessageTooLargeError):
         await backend.put(str(uid), message)
+
+
+@pytest.mark.asyncio
+async def test_redis_backend_gravestone_expire(mock_redis) -> None:
+    backend = RedisBackend(gravestone_expiration_s=1)
+    user_id = str(uuid.uuid4())
+    uid = UserId.new()
+    await backend.create_mailbox(user_id, uid)
+    await asyncio.sleep(2)
+    assert await backend.check_mailbox(user_id, uid) == MailboxStatus.MISSING
+
+    # Mailbox does not expire because of get call
+    await backend.create_mailbox(user_id, uid)
+    message = Message.create(src=uid, dest=uid, body=PingRequest())
+    await backend.put(user_id, message)
+    await asyncio.sleep(0.5)
+    assert await backend.get(user_id, uid) == message
+    await asyncio.sleep(0.5)
+    assert await backend.check_mailbox(user_id, uid) == MailboxStatus.ACTIVE
+
+    await backend.terminate(user_id, uid)
+    assert (
+        await backend.check_mailbox(user_id, uid) == MailboxStatus.TERMINATED
+    )
+    await asyncio.sleep(2)
+    assert await backend.check_mailbox(user_id, uid) == MailboxStatus.MISSING
+
+
+@pytest.mark.asyncio
+async def test_redis_backend_mailbox_expire(mock_redis) -> None:
+    backend = RedisBackend(mailbox_expiration_s=1)
+    user_id = str(uuid.uuid4())
+    uid = UserId.new()
+    await backend.create_mailbox(user_id, uid)
+    message = Message.create(src=uid, dest=uid, body=PingRequest())
+
+    # Message expires after 2 seconds
+    await backend.put(user_id, message)
+    await asyncio.sleep(2)
+    with pytest.raises(TimeoutError):
+        await backend.get(user_id, uid, timeout=0.01)
+
+    # Get extends expiration
+    await backend.put(user_id, message)
+    await backend.put(user_id, message)
+    await backend.put(user_id, message)
+    await asyncio.sleep(0.5)
+    assert await backend.get(user_id, uid) == message
+    await asyncio.sleep(0.5)
+    assert await backend.get(user_id, uid) == message
+    await asyncio.sleep(2)
+    with pytest.raises(TimeoutError):
+        await backend.get(user_id, uid, timeout=0.01)
+
+    await backend.terminate(user_id, uid)


### PR DESCRIPTION
## Summary
Adding automatic expiration to mailboxes and to gravestones. The current expiration policies are:
- The active key and owner key and agent key are created with an expiration based on the gravestone expiration.
- When a message is put in the mailbox a queue is created with an expiration based on the mailbox expiration. 
- The active key, owner key, agent key and queue key lifetimes are extended on a read from the mailbox. 
- Writes to the mailbox do not extend the lifetime of any key.
- Termination extends the life of the active key by the gravestone expiration, and deletes all other keys

These policies are currently quite arbitrary and will need to be tuned based on use and feedback.

## Related Issues
- Closes #196 

## Changes
- [x] Enhancement (non-breaking change or feature addition)


## Pull Request Checklist

Please confirm the PR meets the following requirements.
- [x] Relevant tags are added based on the types of changes.
- [x] Code changes pass `pre-commit` (e.g., ruff, mypy, etc.).
- [x] Tests have been added to show the fix is effective or that the new feature works.
- [x] New and existing unit tests pass locally with the changes.
- [x] Docs have been updated and reviewed if relevant.
